### PR TITLE
feat: create Directory.Build.props with shared MSBuild properties

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -28,7 +28,7 @@
 
 | Task | Milestone | Agent | Status | Detail |
 |------|-----------|-------|--------|--------|
-| | | | | |
+| #8 Create Directory.Build.props | M0 | Executor | Done | Shared TFM, nullable, implicit usings, warnings-as-errors |
 
 ## Decisions
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Assembly Metadata">
+    <Product>Typewriter Standalone CLI</Product>
+    <Company>Typewriter Contributors</Company>
+    <Copyright>Copyright © Typewriter Contributors. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Creates `Directory.Build.props` at the repository root to centralize shared MSBuild properties across all projects
- Sets `net10.0` as the shared target framework, enables nullable reference types and implicit usings
- Enables `TreatWarningsAsErrors` for quality gating
- Adds common assembly metadata (product name, company, copyright)

Closes #8

## Test plan

- [ ] Verify `Directory.Build.props` exists at repo root with correct XML structure
- [ ] Confirm future projects inherit `net10.0` TFM without declaring it individually
- [ ] Confirm nullable, implicit usings, and warnings-as-errors are inherited by all projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)