### PR TITLE
feat: create global.json with .NET 10 SDK pinning

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M0 - Repo bootstrap and packaging skeleton
 - **Status**: Not started
 - **Blocker**: None
-- **Next step**: Create solution layout, project files, and Directory.Build.props per Section 5.1 of DETAILED_IMPLEMENTATION_PLAN.md
+- **Next step**: Create solution layout and project files per Section 5.1 of DETAILED_IMPLEMENTATION_PLAN.md
 
 ## Milestone Map
 
@@ -29,6 +29,7 @@
 | Task | Milestone | Agent | Status | Detail |
 |------|-----------|-------|--------|--------|
 | #8 Create Directory.Build.props | M0 | Executor | Done | Shared TFM, nullable, implicit usings, warnings-as-errors |
+| #18 Create global.json with .NET 10 SDK pin | M0 | Executor | Done | SDK 10.0.100, rollForward: latestFeature |
 
 ## Decisions
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `global.json` at repo root pinning .NET 10 SDK version `10.0.100`
- Use `rollForward: latestFeature` to allow minor SDK updates while maintaining .NET 10 compatibility
- Compatible with `actions/setup-dotnet` in CI

## Test plan

- [ ] Verify `global.json` exists at repo root
- [ ] Verify `dotnet --version` respects the SDK pin when .NET 10 SDK is installed
- [ ] Verify no existing files were modified (other than `.ai/progress.md` tracker)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)