### PR TITLE
feat: create test project .csproj files with xUnit

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,13 +7,13 @@
 - **Active milestone**: M0 - Repo bootstrap and packaging skeleton
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Create solution file (.sln) to tie all projects together; add test projects
+- **Next step**: Create solution file (.sln) to tie all projects together
 
 ## Milestone Map
 
 | Milestone | Name | Status | Notes |
 |-----------|------|--------|-------|
-| M0 | Repo bootstrap and packaging skeleton | In progress | Directory.Build.props, global.json, project graph done |
+| M0 | Repo bootstrap and packaging skeleton | In progress | Directory.Build.props, global.json, project graph, test projects done |
 | M1 | Core reuse extraction (CodeModel/Metadata) | Not started | |
 | M2 | CLI contract, diagnostics, and configuration precedence | Not started | |
 | M3 | MSBuild loading: `.csproj` and restore pipeline | Not started | |
@@ -31,6 +31,7 @@
 | #8 Create Directory.Build.props | M0 | Executor | Done | Shared TFM, nullable, implicit usings, warnings-as-errors |
 | #18 Create global.json with .NET 10 SDK pin | M0 | Executor | Done | SDK 10.0.100, rollForward: latestFeature |
 | #19 Create source project .csproj files with dependency graph | M0 | Executor | Done | 7 projects, placeholder classes, full dependency graph |
+| #20 Create test project .csproj files with xUnit | M0 | Executor | Done | 4 test projects, xUnit packages, placeholder tests |
 
 ## Decisions
 

--- a/tests/Typewriter.GoldenTests/PlaceholderTests.cs
+++ b/tests/Typewriter.GoldenTests/PlaceholderTests.cs
@@ -1,0 +1,7 @@
+namespace Typewriter.GoldenTests;
+
+public class PlaceholderTests
+{
+    [Fact]
+    public void Placeholder_ShouldPass() => Assert.True(true);
+}

--- a/tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj
+++ b/tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Typewriter.Cli\Typewriter.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Application\Typewriter.Application.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.CodeModel\Typewriter.CodeModel.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata\Typewriter.Metadata.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata.Roslyn\Typewriter.Metadata.Roslyn.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Generation\Typewriter.Generation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Typewriter.IntegrationTests/PlaceholderTests.cs
+++ b/tests/Typewriter.IntegrationTests/PlaceholderTests.cs
@@ -1,0 +1,7 @@
+namespace Typewriter.IntegrationTests;
+
+public class PlaceholderTests
+{
+    [Fact]
+    public void Placeholder_ShouldPass() => Assert.True(true);
+}

--- a/tests/Typewriter.IntegrationTests/Typewriter.IntegrationTests.csproj
+++ b/tests/Typewriter.IntegrationTests/Typewriter.IntegrationTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Typewriter.Cli\Typewriter.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Application\Typewriter.Application.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.CodeModel\Typewriter.CodeModel.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata\Typewriter.Metadata.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata.Roslyn\Typewriter.Metadata.Roslyn.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Generation\Typewriter.Generation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Typewriter.PerformanceTests/PlaceholderTests.cs
+++ b/tests/Typewriter.PerformanceTests/PlaceholderTests.cs
@@ -1,0 +1,7 @@
+namespace Typewriter.PerformanceTests;
+
+public class PlaceholderTests
+{
+    [Fact]
+    public void Placeholder_ShouldPass() => Assert.True(true);
+}

--- a/tests/Typewriter.PerformanceTests/Typewriter.PerformanceTests.csproj
+++ b/tests/Typewriter.PerformanceTests/Typewriter.PerformanceTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Typewriter.Cli\Typewriter.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Application\Typewriter.Application.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.CodeModel\Typewriter.CodeModel.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata\Typewriter.Metadata.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata.Roslyn\Typewriter.Metadata.Roslyn.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Generation\Typewriter.Generation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Typewriter.UnitTests/PlaceholderTests.cs
+++ b/tests/Typewriter.UnitTests/PlaceholderTests.cs
@@ -1,0 +1,7 @@
+namespace Typewriter.UnitTests;
+
+public class PlaceholderTests
+{
+    [Fact]
+    public void Placeholder_ShouldPass() => Assert.True(true);
+}

--- a/tests/Typewriter.UnitTests/Typewriter.UnitTests.csproj
+++ b/tests/Typewriter.UnitTests/Typewriter.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Typewriter.Cli\Typewriter.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Application\Typewriter.Application.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.CodeModel\Typewriter.CodeModel.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata\Typewriter.Metadata.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Metadata.Roslyn\Typewriter.Metadata.Roslyn.csproj" />
+    <ProjectReference Include="..\..\src\Typewriter.Generation\Typewriter.Generation.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Add 4 test projects (UnitTests, IntegrationTests, GoldenTests, PerformanceTests) with xUnit dependencies
- Each project references all 7 `src/` projects and includes `xunit`, `xunit.runner.visualstudio`, and `Microsoft.NET.Test.Sdk` packages
- Each project has a placeholder `[Fact]` test that passes
- Properties (`TargetFramework`, `Nullable`, `ImplicitUsings`, `TreatWarningsAsErrors`) are inherited from `Directory.Build.props` — not duplicated

Closes #20

## Test plan

- [ ] `dotnet restore` succeeds for all test projects
- [ ] `dotnet build -c Release` succeeds for all test projects
- [ ] `dotnet test -c Release` succeeds with all 4 placeholder tests passing
- [ ] `origin/` directory remains untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)