### PR TITLE
fix: verify M0 acceptance criteria and fix build issues

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -5,15 +5,15 @@
 ## Current State
 
 - **Active milestone**: M0 - Repo bootstrap and packaging skeleton
-- **Status**: In progress
+- **Status**: Complete (verified)
 - **Blocker**: None
-- **Next step**: Complete remaining M0 tasks, then begin M1 - Core reuse extraction (CodeModel/Metadata)
+- **Next step**: Begin M1 - Core reuse extraction (CodeModel/Metadata)
 
 ## Milestone Map
 
 | Milestone | Name | Status | Notes |
 |-----------|------|--------|-------|
-| M0 | Repo bootstrap and packaging skeleton | In progress | Directory.Build.props, global.json, project graph, test projects done |
+| M0 | Repo bootstrap and packaging skeleton | Done | All acceptance criteria verified: build, test, pack, tool install |
 | M1 | Core reuse extraction (CodeModel/Metadata) | Not started | |
 | M2 | CLI contract, diagnostics, and configuration precedence | Not started | |
 | M3 | MSBuild loading: `.csproj` and restore pipeline | Not started | |
@@ -34,6 +34,7 @@
 | #20 Create test project .csproj files with xUnit | M0 | Executor | Done | 4 test projects, xUnit packages, placeholder tests |
 | #21 Create Typewriter.Cli.slnx solution file | M0 | Executor | Done | .slnx with all 11 projects in src/tests folders |
 | #22 Create .github/workflows/ci.yml | M0 | Executor | Done | Cross-platform CI: restore, build, test, pack on 3 OS matrix |
+| #23 Verify M0 acceptance criteria | M0 | Executor | Done | Build/test/pack/tool-install verified; .gitignore added; SDK warnings suppressed |
 
 ## Decisions
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Build results
+[Bb]in/
+[Oo]bj/
+
+# NuGet
+*.nupkg
+artifacts/
+
+# User-specific files
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# IDE
+.vs/
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# dotnet tool manifest (generated per-machine)
+dotnet-tools.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Suppress external-package locale warnings (NETSDK1188) and preview SDK notice (NETSDK1057) -->
+    <NoWarn>$(NoWarn);NETSDK1188;NETSDK1057</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Metadata">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestFeature"
+    "version": "10.0.100-rc.2.25502.107",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
## Summary

- Added `.gitignore` for build artifacts, NuGet packages, and IDE files
- Updated `global.json` to pin .NET 10 RC SDK with `allowPrerelease: true` (required since .NET 10 is still in RC)
- Suppressed NETSDK1188 (external-package locale warnings) and NETSDK1057 (preview SDK notice) in `Directory.Build.props` — these are SDK-level warnings from NuGet packages, not code warnings
- Updated `.ai/progress.md` to mark M0 as complete

## Verification Results

All M0 acceptance criteria verified:

- `dotnet build Typewriter.Cli.slnx -c Release` — 0 errors, 0 warnings
- `dotnet test Typewriter.Cli.slnx -c Release` — 4 test projects, all passing
- `dotnet pack src/Typewriter.Cli/Typewriter.Cli.csproj -c Release -o ./artifacts/nupkg` — produces `Typewriter.Cli.1.0.0.nupkg`
- `dotnet tool install --local --add-source ./artifacts/nupkg Typewriter.Cli` — installs and runs successfully
- `origin/` directory remains untouched

Closes #23

## Test plan

- [x] `dotnet build` succeeds with zero errors and zero warnings
- [x] `dotnet test` succeeds with all tests passing
- [x] `dotnet pack` produces a `.nupkg`
- [x] `dotnet tool install --local` works
- [x] `origin/` is unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)