### PR TITLE
feat: port 19 metadata interface files into Typewriter.Metadata (T002)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M1 - Core reuse extraction (CodeModel/Metadata)
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: T002–T008 — port clean files into new project structure; rewrite 4 VS-coupled files
+- **Next step**: T003–T008 — port remaining clean files (collections, implementations, helpers, Roslyn); rewrite 4 VS-coupled files
 
 ## Milestone Map
 
@@ -37,6 +37,7 @@
 | #23 Verify M0 acceptance criteria | M0 | Executor | Done | Build/test/pack/tool-install verified; .gitignore added; SDK warnings suppressed |
 | #24 Update .ai/progress.md for M0 | M0 | Executor | Done | Progress tracker created with all §14 sections; M0 status documented |
 | T001 M1 compat checklist audit | M1 | Executor | Done | [T001-m1-compat-checklist.md](.ai/tasks/T001-m1-compat-checklist.md) — 77/81 files clean, 4 VS-coupled confirmed |
+| T002 Port metadata interfaces (#35) | M1 | Executor | Done | [T002-port-metadata-interfaces.md](.ai/tasks/T002-port-metadata-interfaces.md) — 19 I*.cs files in `src/Typewriter.Metadata/Interfaces/` |
 
 ## Decisions
 

--- a/.ai/tasks/T002-port-metadata-interfaces.md
+++ b/.ai/tasks/T002-port-metadata-interfaces.md
@@ -1,0 +1,65 @@
+# T002: Port Metadata Interfaces (I*.cs)
+- Milestone: M1
+- Status: Done
+- Agent: Executor (claude-sonnet-4-6)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+
+Copy the 19 metadata interface files from `origin/src/Metadata/Interfaces/I*.cs` into `src/Typewriter.Metadata/Interfaces/`, updating namespaces from `Typewriter.Metadata.Interfaces` to `Typewriter.Metadata`.
+
+## Approach
+
+1. Read all 19 origin interface files to confirm content and namespaces.
+2. Create `src/Typewriter.Metadata/Interfaces/` directory.
+3. Write each file with:
+   - File-scoped namespace syntax (`namespace Typewriter.Metadata;`)
+   - No BOM
+   - Content identical to origin (no VS references to remove — all 19 were clean per T001 audit)
+
+## Journey
+
+### 2026-03-02
+
+- Confirmed 19 files in `origin/src/Metadata/Interfaces/I*.cs` via glob.
+- Confirmed all files used block-scoped `namespace Typewriter.Metadata.Interfaces { ... }` in origin.
+- T001 audit confirmed: all 19 files are **clean** — no `EnvDTE`, `Microsoft.VisualStudio.*`, or COM references.
+- Created `src/Typewriter.Metadata/Interfaces/` directory.
+- Wrote all 19 files using file-scoped namespace `Typewriter.Metadata;` (modern .NET 10 style, consistent with `Placeholder.cs`).
+- Verified no VS/COM references in ported files.
+- Verified all 19 files exist and all have `namespace Typewriter.Metadata;`.
+- dotnet SDK not available in execution environment; build verification deferred to CI.
+
+## Outcome
+
+All 19 interface files created under `src/Typewriter.Metadata/Interfaces/`:
+
+| File | Namespace | Notes |
+|------|-----------|-------|
+| IAttributeArgumentMetadata.cs | Typewriter.Metadata | Clean port |
+| IAttributeMetadata.cs | Typewriter.Metadata | Clean port |
+| IClassMetadata.cs | Typewriter.Metadata | Clean port |
+| IConstantMetadata.cs | Typewriter.Metadata | Clean port |
+| IDelegateMetadata.cs | Typewriter.Metadata | Clean port |
+| IEnumMetadata.cs | Typewriter.Metadata | Clean port |
+| IEnumValueMetadata.cs | Typewriter.Metadata | Clean port |
+| IEventMetadata.cs | Typewriter.Metadata | Clean port |
+| IFieldMetadata.cs | Typewriter.Metadata | Clean port |
+| IFileMetadata.cs | Typewriter.Metadata | Clean port |
+| IInterfaceMetadata.cs | Typewriter.Metadata | Clean port |
+| IMethodMetadata.cs | Typewriter.Metadata | Clean port |
+| INamedItem.cs | Typewriter.Metadata | Clean port |
+| IParameterMetadata.cs | Typewriter.Metadata | Clean port |
+| IPropertyMetadata.cs | Typewriter.Metadata | Clean port |
+| IRecordMetadata.cs | Typewriter.Metadata | Clean port |
+| IStaticReadOnlyFieldMetadata.cs | Typewriter.Metadata | Clean port |
+| ITypeMetadata.cs | Typewriter.Metadata | Clean port |
+| ITypeParameterMetadata.cs | Typewriter.Metadata | Clean port |
+
+`origin/` unchanged.
+
+## Follow-ups
+
+- T003+: Port collections (`origin/src/Typewriter/CodeModel/Collections/`) into `src/Typewriter.CodeModel/`
+- Future tasks consuming these interfaces will need `using Typewriter.Metadata;`

--- a/src/Typewriter.Metadata/Interfaces/IAttributeArgumentMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IAttributeArgumentMetadata.cs
@@ -1,0 +1,10 @@
+namespace Typewriter.Metadata;
+
+public interface IAttributeArgumentMetadata
+{
+    ITypeMetadata Type { get; }
+
+    ITypeMetadata TypeValue { get; }
+
+    object GetValue();
+}

--- a/src/Typewriter.Metadata/Interfaces/IAttributeMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IAttributeMetadata.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IAttributeMetadata : INamedItem
+{
+    string Value { get; }
+
+    IEnumerable<IAttributeArgumentMetadata> Arguments { get; }
+
+    ITypeMetadata Type { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IClassMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IClassMetadata.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IClassMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    bool IsAbstract { get; }
+
+    bool IsGeneric { get; }
+
+    bool IsStatic { get; }
+
+    string Namespace { get; }
+
+    ITypeMetadata Type { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    IClassMetadata BaseClass { get; }
+
+    IClassMetadata ContainingClass { get; }
+
+    IEnumerable<IConstantMetadata> Constants { get; }
+
+    IEnumerable<IDelegateMetadata> Delegates { get; }
+
+    IEnumerable<IEventMetadata> Events { get; }
+
+    IEnumerable<IFieldMetadata> Fields { get; }
+
+    IEnumerable<IInterfaceMetadata> Interfaces { get; }
+
+    IEnumerable<IMethodMetadata> Methods { get; }
+
+    IEnumerable<IPropertyMetadata> Properties { get; }
+
+    IEnumerable<IStaticReadOnlyFieldMetadata> StaticReadOnlyFields { get; }
+
+    IEnumerable<ITypeParameterMetadata> TypeParameters { get; }
+
+    IEnumerable<ITypeMetadata> TypeArguments { get; }
+
+    IEnumerable<IClassMetadata> NestedClasses { get; }
+
+    IEnumerable<IEnumMetadata> NestedEnums { get; }
+
+    IEnumerable<IInterfaceMetadata> NestedInterfaces { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IConstantMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IConstantMetadata.cs
@@ -1,0 +1,6 @@
+namespace Typewriter.Metadata;
+
+public interface IConstantMetadata : IFieldMetadata
+{
+    string Value { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IDelegateMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IDelegateMetadata.cs
@@ -1,0 +1,5 @@
+namespace Typewriter.Metadata;
+
+public interface IDelegateMetadata : IMethodMetadata
+{
+}

--- a/src/Typewriter.Metadata/Interfaces/IEnumMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IEnumMetadata.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IEnumMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    string Namespace { get; }
+
+    ITypeMetadata Type { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    IClassMetadata ContainingClass { get; }
+
+    IEnumerable<IEnumValueMetadata> Values { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IEnumValueMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IEnumValueMetadata.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IEnumValueMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    long Value { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IEventMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IEventMetadata.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IEventMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    ITypeMetadata Type { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IFieldMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IFieldMetadata.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IFieldMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    ITypeMetadata Type { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IFileMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IFileMetadata.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IFileMetadata
+{
+    string Name { get; }
+
+    string FullName { get; }
+
+    IEnumerable<IClassMetadata> Classes { get; }
+
+    IEnumerable<IDelegateMetadata> Delegates { get; }
+
+    IEnumerable<IEnumMetadata> Enums { get; }
+
+    IEnumerable<IInterfaceMetadata> Interfaces { get; }
+
+    IEnumerable<IRecordMetadata> Records { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IInterfaceMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IInterfaceMetadata.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IInterfaceMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    string Namespace { get; }
+
+    bool IsGeneric { get; }
+
+    ITypeMetadata Type { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    IClassMetadata ContainingClass { get; }
+
+    IEnumerable<IEventMetadata> Events { get; }
+
+    IEnumerable<ITypeParameterMetadata> TypeParameters { get; }
+
+    IEnumerable<ITypeMetadata> TypeArguments { get; }
+
+    IEnumerable<IInterfaceMetadata> Interfaces { get; }
+
+    IEnumerable<IMethodMetadata> Methods { get; }
+
+    IEnumerable<IPropertyMetadata> Properties { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IMethodMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IMethodMetadata.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IMethodMetadata : IFieldMetadata
+{
+    bool IsAbstract { get; }
+
+    bool IsGeneric { get; }
+
+    IEnumerable<ITypeParameterMetadata> TypeParameters { get; }
+
+    IEnumerable<IParameterMetadata> Parameters { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/INamedItem.cs
+++ b/src/Typewriter.Metadata/Interfaces/INamedItem.cs
@@ -1,0 +1,10 @@
+namespace Typewriter.Metadata;
+
+public interface INamedItem
+{
+    string Name { get; }
+
+    string FullName { get; }
+
+    string AssemblyName { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IParameterMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IParameterMetadata.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IParameterMetadata : INamedItem
+{
+    bool HasDefaultValue { get; }
+
+    string DefaultValue { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    ITypeMetadata Type { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IPropertyMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IPropertyMetadata.cs
@@ -1,0 +1,12 @@
+namespace Typewriter.Metadata;
+
+public interface IPropertyMetadata : IFieldMetadata
+{
+    bool IsAbstract { get; }
+
+    bool IsVirtual { get; }
+
+    bool HasGetter { get; }
+
+    bool HasSetter { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IRecordMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IRecordMetadata.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface IRecordMetadata : INamedItem
+{
+    string DocComment { get; }
+
+    bool IsAbstract { get; }
+
+    bool IsGeneric { get; }
+
+    string Namespace { get; }
+
+    ITypeMetadata Type { get; }
+
+    IEnumerable<IAttributeMetadata> Attributes { get; }
+
+    IRecordMetadata BaseRecord { get; }
+
+    IRecordMetadata ContainingRecord { get; }
+
+    IEnumerable<IConstantMetadata> Constants { get; }
+
+    IEnumerable<IDelegateMetadata> Delegates { get; }
+
+    IEnumerable<IEventMetadata> Events { get; }
+
+    IEnumerable<IFieldMetadata> Fields { get; }
+
+    IEnumerable<IInterfaceMetadata> Interfaces { get; }
+
+    IEnumerable<IMethodMetadata> Methods { get; }
+
+    IEnumerable<IPropertyMetadata> Properties { get; }
+
+    IEnumerable<IStaticReadOnlyFieldMetadata> StaticReadOnlyFields { get; }
+
+    IEnumerable<ITypeParameterMetadata> TypeParameters { get; }
+
+    IEnumerable<ITypeMetadata> TypeArguments { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/IStaticReadOnlyFieldMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/IStaticReadOnlyFieldMetadata.cs
@@ -1,0 +1,6 @@
+namespace Typewriter.Metadata;
+
+public interface IStaticReadOnlyFieldMetadata : IFieldMetadata
+{
+    string Value { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/ITypeMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/ITypeMetadata.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Typewriter.Metadata;
+
+public interface ITypeMetadata : IClassMetadata
+{
+    bool IsDictionary { get; }
+
+    bool IsDynamic { get; }
+
+    bool IsEnum { get; }
+
+    bool IsEnumerable { get; }
+
+    bool IsNullable { get; }
+
+    bool IsTask { get; }
+
+    bool IsDefined { get; }
+
+    bool IsValueTuple { get; }
+
+    ITypeMetadata ElementType { get; }
+
+    IEnumerable<IFieldMetadata> TupleElements { get; }
+
+    IEnumerable<string> FileLocations { get; }
+
+    string DefaultValue { get; }
+}

--- a/src/Typewriter.Metadata/Interfaces/ITypeParameterMetadata.cs
+++ b/src/Typewriter.Metadata/Interfaces/ITypeParameterMetadata.cs
@@ -1,0 +1,6 @@
+namespace Typewriter.Metadata;
+
+public interface ITypeParameterMetadata
+{
+    string Name { get; }
+}


### PR DESCRIPTION
## Summary

- Copies all 19 `I*.cs` metadata interface files from `origin/src/Metadata/Interfaces/` into `src/Typewriter.Metadata/Interfaces/`
- Updates namespace from `Typewriter.Metadata.Interfaces` (block-scoped) to `Typewriter.Metadata` (file-scoped, modern .NET style)
- No `EnvDTE`, `Microsoft.VisualStudio.*`, or COM references — all 19 files confirmed clean by T001 audit
- `origin/` is unchanged

## What changed

**New files** (`src/Typewriter.Metadata/Interfaces/`):
`IAttributeArgumentMetadata`, `IAttributeMetadata`, `IClassMetadata`, `IConstantMetadata`, `IDelegateMetadata`, `IEnumMetadata`, `IEnumValueMetadata`, `IEventMetadata`, `IFieldMetadata`, `IFileMetadata`, `IInterfaceMetadata`, `IMethodMetadata`, `INamedItem`, `IParameterMetadata`, `IPropertyMetadata`, `IRecordMetadata`, `IStaticReadOnlyFieldMetadata`, `ITypeMetadata`, `ITypeParameterMetadata`

**Updated**: `.ai/progress.md`, `.ai/tasks/T002-port-metadata-interfaces.md`

## Test plan

- [x] 19 interface files exist under `src/Typewriter.Metadata/Interfaces/`
- [x] All namespaces set to `Typewriter.Metadata`
- [x] No VS/COM references in any ported file
- [ ] `dotnet build src/Typewriter.Metadata` succeeds (CI gated — dotnet SDK not in executor environment)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)