### PR TITLE
feat: port IMetadataProvider interface into Typewriter.Metadata (T003)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor)
+> Last touched: 2026-03-02 by Claude (Executor, T003)
 
 ## Current State
 
 - **Active milestone**: M1 - Core reuse extraction (CodeModel/Metadata)
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: T003–T008 — port remaining clean files (collections, implementations, helpers, Roslyn); rewrite 4 VS-coupled files
+- **Next step**: T004–T008 — port remaining clean files (collections, implementations, helpers, Roslyn); rewrite 4 VS-coupled files; replace Settings stub when Settings is properly ported
 
 ## Milestone Map
 
@@ -38,6 +38,7 @@
 | #24 Update .ai/progress.md for M0 | M0 | Executor | Done | Progress tracker created with all §14 sections; M0 status documented |
 | T001 M1 compat checklist audit | M1 | Executor | Done | [T001-m1-compat-checklist.md](.ai/tasks/T001-m1-compat-checklist.md) — 77/81 files clean, 4 VS-coupled confirmed |
 | T002 Port metadata interfaces (#35) | M1 | Executor | Done | [T002-port-metadata-interfaces.md](.ai/tasks/T002-port-metadata-interfaces.md) — 19 I*.cs files in `src/Typewriter.Metadata/Interfaces/` |
+| T003 Port IMetadataProvider (#36) | M1 | Executor | Done | [T003-port-imetadataprovider-interface.md](.ai/tasks/T003-port-imetadataprovider-interface.md) — `IMetadataProvider.cs` + minimal `Settings` stub in `src/Typewriter.Metadata/` |
 
 ## Decisions
 

--- a/.ai/tasks/T003-port-imetadataprovider-interface.md
+++ b/.ai/tasks/T003-port-imetadataprovider-interface.md
@@ -1,0 +1,46 @@
+# T003: Port IMetadataProvider Interface
+- Milestone: M1
+- Status: Done
+- Agent: Executor (claude-sonnet-4-6)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+
+Copy `origin/src/Metadata/Providers/IMetadataProvider.cs` into `src/Typewriter.Metadata/Providers/`, updating the namespace to `Typewriter.Metadata`.
+
+## Approach
+
+1. Read origin file to confirm content (confirmed clean by T001 audit).
+2. Create `src/Typewriter.Metadata/Providers/IMetadataProvider.cs` with file-scoped namespace `Typewriter.Metadata;`.
+3. Remove `using Typewriter.Metadata.Interfaces;` (not needed — `IFileMetadata` already in same namespace after T002).
+4. Remove `using Typewriter.Configuration;` (replaced by local `Settings` type).
+5. Resolve `Settings` dependency: `Settings` is in `origin/src/CodeModel/Configuration/Settings.cs` mapping to `src/Typewriter.CodeModel/`, but `Typewriter.CodeModel` depends on `Typewriter.Metadata` — circular dependency. Created a minimal abstract `Settings` stub in `src/Typewriter.Metadata/Settings.cs` to satisfy the build until `Settings` is properly ported in a future task.
+
+## Journey
+
+### 2026-03-02
+
+- Confirmed `origin/src/Metadata/Providers/IMetadataProvider.cs` — clean (no VS/COM refs), uses `Typewriter.Configuration.Settings` and `Typewriter.Metadata.Interfaces.IFileMetadata`.
+- T001 audit already confirmed this file as **clean**.
+- Identified `Settings` dependency issue: origin `Settings.cs` is in `Typewriter.Configuration` namespace, mapped per plan to `src/Typewriter.CodeModel/`. Since `Typewriter.CodeModel` → `Typewriter.Metadata` (CodeModel depends on Metadata), having Metadata depend on CodeModel for `Settings` would create a circular dependency.
+- Resolution: `Settings` abstract base must live in `Typewriter.Metadata` (or a shared library with no deps). Created minimal stub `src/Typewriter.Metadata/Settings.cs` with `namespace Typewriter.Metadata; public abstract class Settings { }`.
+- `dotnet` not available in execution environment; build verification deferred to CI.
+- Created `src/Typewriter.Metadata/Providers/IMetadataProvider.cs` with file-scoped namespace `Typewriter.Metadata;`, `using System;` for `Action<string[]>`, referencing `IFileMetadata` and `Settings` from same namespace.
+- Verified `origin/` unchanged.
+
+## Outcome
+
+Two files created:
+
+| File | Notes |
+|------|-------|
+| `src/Typewriter.Metadata/Providers/IMetadataProvider.cs` | Clean port; namespace `Typewriter.Metadata`; no VS/COM refs |
+| `src/Typewriter.Metadata/Settings.cs` | Minimal stub for `Settings`; required to satisfy build dependency; to be replaced when `origin/src/CodeModel/Configuration/Settings.cs` is ported |
+
+`origin/` unchanged.
+
+## Follow-ups
+
+- Future task: port `origin/src/CodeModel/Configuration/Settings.cs` and `PartialRenderingMode.cs` to `src/Typewriter.Metadata/` (or `src/Typewriter.CodeModel/` with the `Settings` abstract base staying in `Typewriter.Metadata`).
+- When `Settings` is properly ported with full members, the stub in `src/Typewriter.Metadata/Settings.cs` must be replaced.

--- a/src/Typewriter.Metadata/Providers/IMetadataProvider.cs
+++ b/src/Typewriter.Metadata/Providers/IMetadataProvider.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Typewriter.Metadata;
+
+public interface IMetadataProvider
+{
+    IFileMetadata GetFile(string path, Settings settings, Action<string[]> requestRender);
+}

--- a/src/Typewriter.Metadata/Settings.cs
+++ b/src/Typewriter.Metadata/Settings.cs
@@ -1,0 +1,4 @@
+namespace Typewriter.Metadata;
+
+// Placeholder stub — will be replaced when origin/src/CodeModel/Configuration/Settings.cs is ported.
+public abstract class Settings { }


### PR DESCRIPTION
## Summary

- Adds `src/Typewriter.Metadata/Providers/IMetadataProvider.cs` ported from `origin/src/Metadata/Providers/IMetadataProvider.cs` with namespace updated to `Typewriter.Metadata` (file-scoped); no VS or COM references.
- Adds `src/Typewriter.Metadata/Settings.cs` as a minimal abstract stub to resolve the `Settings` dependency in `IMetadataProvider`; required because `Settings` in origin resides in `Typewriter.Configuration` (under `CodeModel`) which would create a circular dependency if placed in `Typewriter.CodeModel` (which already depends on `Typewriter.Metadata`). This stub will be replaced when `Settings` is properly ported.
- Updates `.ai/progress.md` and adds `.ai/tasks/T003-port-imetadataprovider-interface.md`.

## Test plan

- [ ] CI build passes: `dotnet build src/Typewriter.Metadata` zero errors
- [ ] `origin/` directory unchanged (verified locally via `git status`)
- [ ] `src/Typewriter.Metadata/Providers/IMetadataProvider.cs` exists with `namespace Typewriter.Metadata;`
- [ ] No VS or COM references in ported files

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)