### PR TITLE
feat: stub/rewrite VS-coupled configuration files (T007)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T006)
+> Last touched: 2026-03-02 by Claude (Executor, T007)
 
 ## Current State
 
 - **Active milestone**: M1 - Core reuse extraction (CodeModel/Metadata)
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: T007–T008 — port Roslyn metadata wrappers (18 clean), rewrite 4 VS-coupled files, reconcile full Settings when deps allow
+- **Next step**: T008 — port Roslyn metadata wrappers (18 clean files from `origin/src/Roslyn/`)
 
 ## Milestone Map
 
@@ -42,6 +42,7 @@
 | T004 Port CodeModel collection impls (#37) | M1 | Executor | Done | [T004-port-codemodel-collection-implem.md](.ai/tasks/T004-port-codemodel-collection-implem.md) — 42 abstract types + 19 CollectionImpl files in `src/Typewriter.CodeModel/` |
 | T005 Port CodeModel impl files (#38) | M1 | Executor | Done | [T005-port-codemodel-implementation-files.md](.ai/tasks/T005-port-codemodel-implementation-files.md) — Helpers.cs + 19 Implementation files in `src/Typewriter.CodeModel/`; Settings stub extended |
 | T006 Port Helpers.cs type-mapping (#39) | M1 | Executor | Done | [T006-port-helpers-type-mapping.md](.ai/tasks/T006-port-helpers-type-mapping.md) — `src/Typewriter.CodeModel/Helpers.cs` already in place from T005; verified all acceptance criteria |
+| T007 Stub/rewrite VS-coupled config (#40) | M1 | Executor | Done | [T007-stubrewrite-vs-coupled-config.md](.ai/tasks/T007-stubrewrite-vs-coupled-config.md) — `SettingsImpl.cs` + `ProjectHelpers.cs` created; `Settings.cs` expanded; zero VS refs |
 
 ## Decisions
 

--- a/.ai/tasks/T007-stubrewrite-vs-coupled-config.md
+++ b/.ai/tasks/T007-stubrewrite-vs-coupled-config.md
@@ -1,0 +1,77 @@
+# T007: Stub/Rewrite VS-Coupled Configuration Files
+- Milestone: M1
+- Status: Done
+- Agent: Executor (claude-sonnet-4-6)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+
+Create CLI-compatible replacements for `SettingsImpl.cs` and `ProjectHelpers.cs`.
+Both files are VS-coupled in origin (EnvDTE, ThreadHelper, VSLangProj) and cannot
+be ported verbatim.
+
+## Approach
+
+1. Read T001 audit confirming VS-coupling in both files.
+2. Expand `src/Typewriter.Metadata/Settings.cs` stub to a full abstract class
+   (noted as a follow-up in T005).
+3. Create `src/Typewriter.CodeModel/Configuration/SettingsImpl.cs` extending
+   `Settings` with a CLI-path-based, immutable-at-construction implementation.
+4. Create `src/Typewriter.CodeModel/Configuration/ProjectHelpers.cs` with
+   filesystem-based stubs; project-graph methods deferred to M3.
+
+## Journey
+
+### 2026-03-02
+
+- Read origin `SettingsImpl.cs` and `ProjectHelpers.cs` to understand all
+  VS-coupled members (`ProjectItem`, `DTE`, `ThreadHelper`, `VSProject`, `Reference`).
+- Read origin `Settings.cs` abstract base class to understand the full interface.
+- Read existing `src/Typewriter.Metadata/Settings.cs` stub (only had `StrictNullGeneration`).
+- Identified circular-dependency constraint: `Settings` (in `Typewriter.Metadata`)
+  cannot include `PartialRenderingMode` (in `Typewriter.CodeModel`) or
+  `OutputFilenameFactory` (uses `Typewriter.CodeModel.File`) without creating a
+  circular project reference. Resolution: keep those members out of the abstract
+  base; add them as concrete properties directly on `SettingsImpl`.
+- Verified `File` type in `Func<File, string>?` on `SettingsImpl` resolves to
+  `Typewriter.CodeModel.File` via C# enclosing-namespace lookup, not
+  `System.IO.File` from implicit usings.
+- dotnet toolchain not present in execution environment; build verification
+  deferred to CI (same situation as T005).
+
+## Outcome
+
+Files created or modified:
+
+| File | Action |
+|------|--------|
+| `src/Typewriter.Metadata/Settings.cs` | Expanded: full abstract class with all portable members |
+| `src/Typewriter.CodeModel/Configuration/SettingsImpl.cs` | Created: CLI impl, no VS/COM refs |
+| `src/Typewriter.CodeModel/Configuration/ProjectHelpers.cs` | Created: filesystem stubs, no VS/COM refs |
+
+**Design decisions:**
+- `PartialRenderingMode` and `OutputFilenameFactory` omitted from `Settings`
+  abstract class to avoid circular project dependency; both added directly to
+  `SettingsImpl`.
+- `ILog`/`Log` omitted entirely — not used by CodeModel in M1; will be
+  reconsidered if needed for M2 CLI diagnostics.
+- `ProjectHelpers`: `AddProject`, `AddCurrentProject`, `AddReferencedProjects`,
+  `AddAllProjects` are M1 no-ops; `GetProjectItems` and `ProjectListContainsItem`
+  use filesystem path matching without DTE.
+- `IncludedProjects` lazy-population pattern from upstream preserved on
+  `SettingsImpl`; mirrors the VS-side behavior (current + referenced projects by
+  default).
+
+**Accepted parity gap (documented):**
+- M1 `IncludeProject(name)`, `IncludeCurrentProject()`, `IncludeReferencedProjects()`,
+  `IncludeAllProjects()` are no-ops. Full MSBuild-backed implementation is M3 scope.
+  This is intentional — see task description and M3 milestone.
+
+`origin/` unchanged.
+
+## Follow-ups
+
+- M3: Replace no-op stubs in `ProjectHelpers` with `ProjectGraph` traversal.
+- M2: Decide whether `ILog` interface belongs in `Typewriter.Metadata` for CLI
+  diagnostics wiring.

--- a/src/Typewriter.CodeModel/Configuration/ProjectHelpers.cs
+++ b/src/Typewriter.CodeModel/Configuration/ProjectHelpers.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Typewriter.CodeModel.Configuration;
+
+/// <summary>
+/// Filesystem-based project-discovery helpers for CLI use.
+/// </summary>
+/// <remarks>
+/// <para>
+/// M1 scope: stubs sufficient for CLI operation without a loaded MSBuild workspace.
+/// Methods that require MSBuild project-graph traversal (named project lookup,
+/// current-project identity, reference resolution, solution enumeration) are
+/// no-ops in M1 and documented for full implementation in M3.
+/// </para>
+/// <para>
+/// Methods that can be answered from the filesystem alone
+/// (<see cref="GetProjectItems"/> and <see cref="ProjectListContainsItem"/>)
+/// are implemented without DTE or <c>ThreadHelper</c>.
+/// </para>
+/// </remarks>
+internal static class ProjectHelpers
+{
+    /// <summary>
+    /// Attempts to find a project named <paramref name="projectName"/> within the
+    /// solution at <paramref name="solutionPath"/> and adds its path to
+    /// <paramref name="projectList"/>.
+    /// </summary>
+    /// <remarks>
+    /// M1 stub — named-project lookup requires MSBuild graph traversal (deferred to M3).
+    /// </remarks>
+    internal static void AddProject(
+        ICollection<string> projectList,
+        string projectName,
+        string solutionPath)
+    {
+        // M1: MSBuild project-graph lookup deferred to M3.
+        _ = projectList;
+        _ = projectName;
+        _ = solutionPath;
+    }
+
+    /// <summary>
+    /// Adds the project that owns the template at <paramref name="currentProjectPath"/>
+    /// to <paramref name="projectList"/>.
+    /// </summary>
+    /// <remarks>
+    /// M1 stub — project identity requires MSBuild loading (deferred to M3).
+    /// </remarks>
+    internal static void AddCurrentProject(
+        ICollection<string> projectList,
+        string currentProjectPath)
+    {
+        // M1: MSBuild project identity deferred to M3.
+        _ = projectList;
+        _ = currentProjectPath;
+    }
+
+    /// <summary>
+    /// Adds projects referenced by <paramref name="currentProjectPath"/> to
+    /// <paramref name="projectList"/>.
+    /// </summary>
+    /// <remarks>
+    /// M1 stub — reference-graph traversal requires MSBuild loading (deferred to M3).
+    /// </remarks>
+    internal static void AddReferencedProjects(
+        ICollection<string> projectList,
+        string currentProjectPath)
+    {
+        // M1: reference graph traversal deferred to M3.
+        _ = projectList;
+        _ = currentProjectPath;
+    }
+
+    /// <summary>
+    /// Adds every project in the solution at <paramref name="solutionPath"/> to
+    /// <paramref name="projectList"/>.
+    /// </summary>
+    /// <remarks>
+    /// M1 stub — solution-level project enumeration requires MSBuild loading (deferred to M3).
+    /// </remarks>
+    internal static void AddAllProjects(
+        string solutionPath,
+        ICollection<string> projectList)
+    {
+        // M1: solution-level enumeration deferred to M3.
+        _ = solutionPath;
+        _ = projectList;
+    }
+
+    /// <summary>
+    /// Enumerates source files matching <paramref name="filter"/> under the
+    /// directories that contain the project files in <paramref name="projectList"/>.
+    /// </summary>
+    /// <remarks>
+    /// M1: filesystem-based; does not validate VS project membership (no DTE).
+    /// </remarks>
+    internal static IEnumerable<string> GetProjectItems(
+        ICollection<string> projectList,
+        string filter)
+    {
+        return projectList
+            .Select(p => new FileInfo(p).Directory)
+            .Where(d => d != null && d.Exists)
+            .SelectMany(d => d!.GetFiles(filter, SearchOption.AllDirectories))
+            .Select(f => f.FullName);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="filename"/> falls under
+    /// the directory of any project file in <paramref name="projectList"/>.
+    /// </summary>
+    /// <remarks>
+    /// M1: filesystem path prefix check; does not consult the DTE solution.
+    /// </remarks>
+    internal static bool ProjectListContainsItem(
+        string filename,
+        ICollection<string> projectList)
+    {
+        return projectList
+            .Select(p => new FileInfo(p).Directory)
+            .Where(d => d != null)
+            .Any(d => filename.StartsWith(d!.FullName, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Typewriter.CodeModel/Configuration/SettingsImpl.cs
+++ b/src/Typewriter.CodeModel/Configuration/SettingsImpl.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using Typewriter.Configuration;
+using Typewriter.Metadata;
+
+namespace Typewriter.CodeModel.Configuration;
+
+/// <summary>
+/// CLI-portable implementation of <see cref="Settings"/>.
+/// Accepts configuration from the CLI context (paths, flags) with no DTE,
+/// no registry, and no <c>ThreadHelper</c> references.
+/// All values are path-based and effectively immutable after construction;
+/// the fluent mutator methods update internal state and return <c>this</c>.
+/// </summary>
+public class SettingsImpl : Settings
+{
+    private readonly string _solutionFullName;
+    private bool _isSingleFileMode;
+    private string? _singleFileName;
+    private char _stringLiteralCharacter = '"';
+    private List<string>? _includedProjects;
+    private bool _strictNullGeneration = true;
+    private bool _utf8BomGeneration = true;
+    private readonly string _templatePath;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SettingsImpl"/>.
+    /// </summary>
+    /// <param name="templatePath">Absolute path to the template file.</param>
+    /// <param name="solutionFullName">
+    ///   Absolute path to the solution or project file used for project-relative
+    ///   resolution. Pass an empty string when no solution context is available.
+    /// </param>
+    /// <param name="includedProjectPaths">
+    ///   Optional pre-populated list of project file paths to include.
+    ///   When <see langword="null"/>, the list is lazily populated on first access
+    ///   via <see cref="IncludeCurrentProject"/> and <see cref="IncludeReferencedProjects"/>
+    ///   (mirrors upstream behaviour).
+    /// </param>
+    public SettingsImpl(
+        string templatePath,
+        string solutionFullName = "",
+        IEnumerable<string>? includedProjectPaths = null)
+    {
+        _templatePath = templatePath;
+        _solutionFullName = solutionFullName;
+
+        if (includedProjectPaths != null)
+        {
+            _includedProjects = new List<string>(includedProjectPaths);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Concrete members not present on the abstract base (require CodeModel types
+    // or would cause circular project-reference dependencies if placed there).
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Gets or sets a value indicating how partial classes and interfaces are rendered.
+    /// </summary>
+    public PartialRenderingMode PartialRenderingMode { get; set; } = PartialRenderingMode.Partial;
+
+    /// <summary>
+    /// Gets or sets a factory that maps a rendered <see cref="File"/> to its output
+    /// filename (including extension). When <see langword="null"/>, the output filename
+    /// is derived from the input source file and <see cref="Settings.OutputExtension"/>.
+    /// </summary>
+    public Func<File, string>? OutputFilenameFactory { get; set; }
+
+    /// <summary>
+    /// Gets the resolved set of project-file paths to include when rendering this template.
+    /// Populated lazily by <see cref="IncludeCurrentProject"/> and
+    /// <see cref="IncludeReferencedProjects"/> on first access (mirrors upstream behaviour).
+    /// </summary>
+    public ICollection<string> IncludedProjects
+    {
+        get
+        {
+            if (_includedProjects == null)
+            {
+                IncludeCurrentProject();
+                IncludeReferencedProjects();
+            }
+
+            return _includedProjects!;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Abstract Settings implementation
+    // -------------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    public override string SolutionFullName => _solutionFullName;
+
+    /// <inheritdoc/>
+    public override bool IsSingleFileMode => _isSingleFileMode;
+
+    /// <inheritdoc/>
+    public override string? SingleFileName => _singleFileName;
+
+    /// <inheritdoc/>
+    public override char StringLiteralCharacter => _stringLiteralCharacter;
+
+    /// <inheritdoc/>
+    public override bool StrictNullGeneration => _strictNullGeneration;
+
+    /// <inheritdoc/>
+    public override bool Utf8BomGeneration => _utf8BomGeneration;
+
+    /// <inheritdoc/>
+    public override string TemplatePath => _templatePath;
+
+    /// <inheritdoc/>
+    public override Settings IncludeProject(string projectName)
+    {
+        _includedProjects ??= new List<string>();
+        ProjectHelpers.AddProject(_includedProjects, projectName, _solutionFullName);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings SingleFileMode(string singleFilename)
+    {
+        _isSingleFileMode = true;
+        _singleFileName = singleFilename;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings IncludeReferencedProjects()
+    {
+        _includedProjects ??= new List<string>();
+        ProjectHelpers.AddReferencedProjects(_includedProjects, _solutionFullName);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings IncludeCurrentProject()
+    {
+        _includedProjects ??= new List<string>();
+        ProjectHelpers.AddCurrentProject(_includedProjects, _solutionFullName);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings IncludeAllProjects()
+    {
+        _includedProjects ??= new List<string>();
+        ProjectHelpers.AddAllProjects(_solutionFullName, _includedProjects);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings UseStringLiteralCharacter(char ch)
+    {
+        _stringLiteralCharacter = ch;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings DisableStrictNullGeneration()
+    {
+        _strictNullGeneration = false;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override Settings DisableUtf8BomGeneration()
+    {
+        _utf8BomGeneration = false;
+        return this;
+    }
+}

--- a/src/Typewriter.Metadata/Settings.cs
+++ b/src/Typewriter.Metadata/Settings.cs
@@ -1,8 +1,109 @@
 namespace Typewriter.Metadata;
 
-// Placeholder stub — will be replaced when origin/src/CodeModel/Configuration/Settings.cs is ported.
-// StrictNullGeneration is required here because Typewriter.CodeModel.Helpers uses it.
+/// <summary>
+/// Provides settings for Typewriter Templates.
+/// </summary>
+/// <remarks>
+/// This is the CLI-portable abstract base class. Members that would require
+/// cross-project type references (<c>PartialRenderingMode</c>,
+/// <c>Typewriter.CodeModel.File</c>) or VS-host types (<c>EnvDTE</c>,
+/// <c>ILog</c>) are intentionally omitted here to avoid circular project
+/// dependencies. Concrete CLI implementations live in
+/// <c>Typewriter.CodeModel.Configuration.SettingsImpl</c> and add those members.
+/// </remarks>
 public abstract class Settings
 {
+    /// <summary>
+    /// Gets or sets the file extension for output files.
+    /// </summary>
+    public string OutputExtension { get; set; } = ".ts";
+
+    /// <summary>
+    /// Gets or sets the output directory to which generated files are saved.
+    /// </summary>
+    public string? OutputDirectory { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether generated files should not be added to the project.
+    /// </summary>
+    public bool SkipAddingGeneratedFilesToProject { get; set; }
+
+    /// <summary>
+    /// Gets the full path of the solution or project file.
+    /// </summary>
+    public abstract string SolutionFullName { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this instance is in single-file mode.
+    /// </summary>
+    public abstract bool IsSingleFileMode { get; }
+
+    /// <summary>
+    /// Gets the name of the single output file when <see cref="IsSingleFileMode"/> is <see langword="true"/>.
+    /// </summary>
+    public abstract string? SingleFileName { get; }
+
+    /// <summary>
+    /// Gets the string literal character used in generated TypeScript. Default is <c>"</c>.
+    /// </summary>
+    public abstract char StringLiteralCharacter { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether strict null generation is enabled.
+    /// When <see langword="true"/>, nullable C# types produce <c>type | null</c> in TypeScript.
+    /// </summary>
     public abstract bool StrictNullGeneration { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether UTF-8 BOM is written to generated output files.
+    /// </summary>
+    public abstract bool Utf8BomGeneration { get; }
+
+    /// <summary>
+    /// Gets the full path to the template file.
+    /// </summary>
+    public abstract string TemplatePath { get; }
+
+    /// <summary>
+    /// Includes files from the project with the given name when rendering the template.
+    /// </summary>
+    public abstract Settings IncludeProject(string projectName);
+
+    /// <summary>
+    /// Switches the template to single-file mode, directing all output to
+    /// <paramref name="singleFilename"/>.
+    /// </summary>
+    public abstract Settings SingleFileMode(string singleFilename);
+
+    /// <summary>
+    /// Includes files from the project that contains the current template file.
+    /// </summary>
+    public abstract Settings IncludeCurrentProject();
+
+    /// <summary>
+    /// Includes files from all projects referenced by the current project.
+    /// </summary>
+    public abstract Settings IncludeReferencedProjects();
+
+    /// <summary>
+    /// Includes files from every project in the solution.
+    /// Note: may have a significant performance impact on large solutions.
+    /// </summary>
+    public abstract Settings IncludeAllProjects();
+
+    /// <summary>
+    /// Sets the string literal delimiter character used in generated TypeScript.
+    /// </summary>
+    public abstract Settings UseStringLiteralCharacter(char ch);
+
+    /// <summary>
+    /// Disables strict null generation; nullable types produce plain <c>type</c>
+    /// instead of <c>type | null</c>.
+    /// </summary>
+    public abstract Settings DisableStrictNullGeneration();
+
+    /// <summary>
+    /// Disables UTF-8 BOM generation in generated output files.
+    /// </summary>
+    public abstract Settings DisableUtf8BomGeneration();
 }


### PR DESCRIPTION
## What changed

Implements T007 — creates CLI-portable replacements for the two VS-coupled configuration files identified in the T001 audit.

### `src/Typewriter.Metadata/Settings.cs`
Expanded from a minimal stub to a full abstract class with all portable members:
- Abstract properties: `SolutionFullName`, `IsSingleFileMode`, `SingleFileName`, `StringLiteralCharacter`, `StrictNullGeneration`, `Utf8BomGeneration`, `TemplatePath`
- Non-abstract properties: `OutputExtension`, `OutputDirectory`, `SkipAddingGeneratedFilesToProject`
- Abstract fluent mutators: `IncludeProject`, `SingleFileMode`, `IncludeCurrentProject`, `IncludeReferencedProjects`, `IncludeAllProjects`, `UseStringLiteralCharacter`, `DisableStrictNullGeneration`, `DisableUtf8BomGeneration`

`PartialRenderingMode` and `OutputFilenameFactory` are intentionally omitted from the abstract class to prevent a circular project dependency (`Typewriter.Metadata` → `Typewriter.CodeModel` → `Typewriter.Metadata`).

### `src/Typewriter.CodeModel/Configuration/SettingsImpl.cs` (new)
CLI implementation of `Settings`:
- Constructor accepts `templatePath`, `solutionFullName`, and optional `includedProjectPaths` — no DTE, no registry, no ThreadHelper
- Adds `PartialRenderingMode` and `OutputFilenameFactory` as concrete properties (same project as `Typewriter.CodeModel.File`, no circular dep)
- Lazy `IncludedProjects` population mirrors upstream behavior

### `src/Typewriter.CodeModel/Configuration/ProjectHelpers.cs` (new)
Filesystem-based project helpers:
- `AddProject`, `AddCurrentProject`, `AddReferencedProjects`, `AddAllProjects` — M1 no-ops, MSBuild graph traversal deferred to M3
- `GetProjectItems`, `ProjectListContainsItem` — filesystem path-based, no DTE

## Why

Both upstream files used `EnvDTE.ProjectItem`, `ThreadHelper.JoinableTaskFactory`, and `VSLangProj` COM types — all incompatible with cross-platform .NET 10 CLI.

## Acceptance criteria verified

- [x] Both files exist under `src/Typewriter.CodeModel/Configuration/` with zero VS/COM references
- [x] `SettingsImpl` accepts configuration from CLI context (no registry, no DTE)
- [x] `ProjectHelpers` provides stub/filesystem-based behavior sufficient for M1
- [x] `origin/` unchanged
- [ ] `dotnet build src/Typewriter.CodeModel` — verified by CI (dotnet not available in local execution environment, consistent with T005/T006)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)