### PR TITLE
feat: verify NuGet refs for Typewriter.Metadata.Roslyn (T009)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T008)
+> Last touched: 2026-03-02 by Claude (Executor, T009)
 
 ## Current State
 
 - **Active milestone**: M1 - Core reuse extraction (CodeModel/Metadata)
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: T009 — wire up `RoslynMetadataProvider` (deferred; see M5 scope)
+- **Next step**: T010 — next M1 task per DETAILED_IMPLEMENTATION_PLAN.md
 
 ## Milestone Map
 
@@ -44,6 +44,7 @@
 | T006 Port Helpers.cs type-mapping (#39) | M1 | Executor | Done | [T006-port-helpers-type-mapping.md](.ai/tasks/T006-port-helpers-type-mapping.md) — `src/Typewriter.CodeModel/Helpers.cs` already in place from T005; verified all acceptance criteria |
 | T007 Stub/rewrite VS-coupled config (#40) | M1 | Executor | Done | [T007-stubrewrite-vs-coupled-config.md](.ai/tasks/T007-stubrewrite-vs-coupled-config.md) — `SettingsImpl.cs` + `ProjectHelpers.cs` created; `Settings.cs` expanded; zero VS refs |
 | T008 Port Roslyn metadata wrappers (#41) | M1 | Executor | Done | [T008-port-roslyn-metadata-wrappers.md](.ai/tasks/T008-port-roslyn-metadata-wrappers.md) — 19 files in `src/Typewriter.Metadata.Roslyn/`; `PartialRenderingMode` moved to `Typewriter.Metadata`; minimal `RoslynFileMetadata` stub |
+| T009 Add NuGet refs to Typewriter.Metadata.Roslyn (#42) | M1 | Executor | Done | [T009-add-nuget-references-to-typewriter-metadata-roslyn.md](.ai/tasks/T009-add-nuget-references-to-typewriter-metadata-roslyn.md) — refs already present from T008; no file changes needed |
 
 ## Decisions
 

--- a/.ai/tasks/T009-add-nuget-references-to-typewriter-metadata-roslyn.md
+++ b/.ai/tasks/T009-add-nuget-references-to-typewriter-metadata-roslyn.md
@@ -1,0 +1,44 @@
+# T009: Add NuGet References to Typewriter.Metadata.Roslyn.csproj
+- Milestone: M1
+- Status: Done
+- Agent: Executor (claude-sonnet-4-6)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+
+Add `Microsoft.CodeAnalysis.CSharp` and `Microsoft.CodeAnalysis.Workspaces.Common` NuGet package
+references to `src/Typewriter.Metadata.Roslyn/Typewriter.Metadata.Roslyn.csproj`, using versions
+consistent with the solution.
+
+## Approach
+
+Check `Directory.Packages.props` and existing `.csproj` files for pinned versions, then add the
+`PackageReference` entries.
+
+## Journey
+
+### 2026-03-02
+
+- Inspected `src/Typewriter.Metadata.Roslyn/Typewriter.Metadata.Roslyn.csproj` — both
+  `PackageReference` entries already present (added as part of T008):
+  - `Microsoft.CodeAnalysis.CSharp` Version="4.*"
+  - `Microsoft.CodeAnalysis.Workspaces.Common` Version="4.*"
+- Verified no `Directory.Packages.props` exists in the repository.
+- Checked all other `src/**/*.csproj` files — none reference `Microsoft.CodeAnalysis` packages,
+  so no conflicting pinned version to align with.
+- The origin (`origin/src/Roslyn/Typewriter.Metadata.Roslyn.csproj`) uses `4.14.0` for the related
+  Roslyn packages; `4.*` resolves within that major range and is consistent.
+- dotnet toolchain not present in the worktree environment; build deferred to CI (same as T008).
+
+## Outcome
+
+No file changes required — acceptance criteria already satisfied by T008:
+
+| File | Status |
+|------|--------|
+| `src/Typewriter.Metadata.Roslyn/Typewriter.Metadata.Roslyn.csproj` | Already contains both PackageReference entries |
+
+## Follow-ups
+
+- None.


### PR DESCRIPTION
## Summary

- Both `Microsoft.CodeAnalysis.CSharp` and `Microsoft.CodeAnalysis.Workspaces.Common` `PackageReference` entries (Version="4.*") were already present in `src/Typewriter.Metadata.Roslyn/Typewriter.Metadata.Roslyn.csproj` — added as part of T008 (#53).
- No `Directory.Packages.props` exists; no other `.csproj` in `src/` references these packages, so `4.*` is consistent with the solution.
- No `.csproj` changes required; all acceptance criteria already satisfied.

## What changed

- Added `.ai/tasks/T009-add-nuget-references-to-typewriter-metadata-roslyn.md` task detail file.
- Updated `.ai/progress.md` to mark T009 as Done.

## Test plan

- [ ] `dotnet restore && dotnet build src/Typewriter.Metadata.Roslyn` — verified by CI (dotnet toolchain not available in worktree environment; consistent with T008 approach)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)