### PR TITLE
feat: verify M1 acceptance criteria (T011)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,20 +1,20 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T010)
+> Last touched: 2026-03-02 by Claude (Executor, T011)
 
 ## Current State
 
 - **Active milestone**: M1 - Core reuse extraction (CodeModel/Metadata)
-- **Status**: In progress
+- **Status**: Done
 - **Blocker**: None
-- **Next step**: M1 complete pending T010 CI verification
+- **Next step**: Begin M2 (CLI contract, diagnostics, configuration precedence)
 
 ## Milestone Map
 
 | Milestone | Name | Status | Notes |
 |-----------|------|--------|-------|
 | M0 | Repo bootstrap and packaging skeleton | Done | All acceptance criteria verified: build, test, pack, tool install |
-| M1 | Core reuse extraction (CodeModel/Metadata) | In progress | Audit T001 done; 77/81 in-scope files clean; 4 VS-coupled blockers identified |
+| M1 | Core reuse extraction (CodeModel/Metadata) | Done | All acceptance criteria verified: build 0 errors, CodeModel 102/102, TypeMapping 71/71, zero VS refs |
 | M2 | CLI contract, diagnostics, and configuration precedence | Not started | |
 | M3 | MSBuild loading: `.csproj` and restore pipeline | Not started | |
 | M4 | MSBuild loading: `.sln` and `.slnx` | Not started | |
@@ -46,6 +46,7 @@
 | T008 Port Roslyn metadata wrappers (#41) | M1 | Executor | Done | [T008-port-roslyn-metadata-wrappers.md](.ai/tasks/T008-port-roslyn-metadata-wrappers.md) — 19 files in `src/Typewriter.Metadata.Roslyn/`; `PartialRenderingMode` moved to `Typewriter.Metadata`; minimal `RoslynFileMetadata` stub |
 | T009 Add NuGet refs to Typewriter.Metadata.Roslyn (#42) | M1 | Executor | Done | [T009-add-nuget-references-to-typewriter-metadata-roslyn.md](.ai/tasks/T009-add-nuget-references-to-typewriter-metadata-roslyn.md) — refs already present from T008; no file changes needed |
 | T010 Add/update unit tests for M1 ported code (#43) | M1 | Executor | Done | [T010-addupdate-unit-tests-for-m1.md](.ai/tasks/T010-addupdate-unit-tests-for-m1.md) — TypeMappingTests (CamelCase, GetTypeScriptName, GetOriginalName, IsPrimitive), CollectionTests (ItemCollectionImpl, ClassCollectionImpl, EnumCollectionImpl, FieldCollectionImpl), RoslynExtensionsTests (GetName, GetFullName, GetNamespace, GetFullTypeName); added Microsoft.CodeAnalysis.CSharp package ref to test project |
+| T011 Run M1 acceptance criteria (#44) | M1 | Executor | Done | [T011-run-m1-acceptance-criteria.md](.ai/tasks/T011-run-m1-acceptance-criteria.md) — build 0 errors; CodeModel 102/102; TypeMapping 71/71; zero VS refs confirmed; origin/ unchanged |
 
 ## Decisions
 

--- a/.ai/tasks/T011-run-m1-acceptance-criteria.md
+++ b/.ai/tasks/T011-run-m1-acceptance-criteria.md
@@ -1,0 +1,34 @@
+# T011: Run M1 Acceptance Criteria
+- Milestone: M1
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Execute and verify all M1 acceptance criteria: build, CodeModel tests, TypeMapping tests, and confirm no VS dependencies.
+
+## Approach
+Run the three required commands against the workspace and verify exit codes + output. Also grep source trees for forbidden references.
+
+## Journey
+### 2026-03-02
+- .NET SDK 10.0.103 not pre-installed in agent environment; installed to `/tmp/dotnet` using the dotnet-install script with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` (no ICU libs on system).
+- `dotnet restore` — all projects already up-to-date.
+- `dotnet build -c Release` — **Build succeeded. 0 Warning(s). 0 Error(s).** All 11 projects compiled (7 src + 4 tests).
+- `dotnet test tests/Typewriter.UnitTests --filter "FullyQualifiedName~CodeModel" -c Release` — **Passed! Failed: 0, Passed: 102, Skipped: 0**.
+- `dotnet test tests/Typewriter.UnitTests --filter "FullyQualifiedName~TypeMapping" -c Release` — **Passed! Failed: 0, Passed: 71, Skipped: 0**.
+- Grepped `src/Typewriter.Metadata`, `src/Typewriter.CodeModel`, `src/Typewriter.Metadata.Roslyn` for `EnvDTE`, `Microsoft.VisualStudio.*`, package references — **zero actual code references**. The single hit in `Settings.cs` was a documentation comment only.
+- `origin/` verified unchanged (clean working tree, no diff).
+
+## Outcome
+All M1 acceptance criteria met:
+- `dotnet build -c Release`: exit 0, 0 errors, 0 warnings
+- CodeModel tests: 102/102 passed
+- TypeMapping tests: 71/71 passed
+- Zero VS/EnvDTE references in target projects (code or packages)
+- `origin/` unchanged
+- Runs on Linux (net10.0, no OS-specific code paths)
+
+## Follow-ups
+- None. M1 gate passed; M2 can begin.


### PR DESCRIPTION
## Summary

- Ran all three M1 gate commands and confirmed they all exit with code `0`
- `dotnet build -c Release`: succeeded with **0 errors, 0 warnings**
- `dotnet test ... --filter "FullyQualifiedName~CodeModel"`: **102/102 passed**
- `dotnet test ... --filter "FullyQualifiedName~TypeMapping"`: **71/71 passed**
- Verified zero `EnvDTE` / `Microsoft.VisualStudio.*` references in `src/Typewriter.Metadata`, `src/Typewriter.CodeModel`, `src/Typewriter.Metadata.Roslyn` (the single hit in `Settings.cs` was a doc comment only)
- Confirmed `origin/` is unchanged
- Updated `.ai/progress.md`: M1 marked **Done**, next step M2
- Created `.ai/tasks/T011-run-m1-acceptance-criteria.md` with full journey notes

Closes #44

## Test plan
- [x] `dotnet build -c Release` exits 0
- [x] CodeModel filter test run exits 0
- [x] TypeMapping filter test run exits 0
- [x] No forbidden VS package references in target projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)