### PR TITLE
feat: implement generate command parser in Typewriter.Cli (T013)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T012)
+> Last touched: 2026-03-02 by Claude (Executor, T013)
 
 ## Current State
 
 - **Active milestone**: M2 - CLI contract, diagnostics, and configuration precedence
-- **Status**: Not started
+- **Status**: In progress
 - **Blocker**: None
-- **Next step**: Implement `generate` command parser in `src/Typewriter.Cli`; implement `typewriter.json` loader and `IDiagnosticReporter` with `TW` code catalog
+- **Next step**: Implement `typewriter.json` loader and precedence merge; implement `TW` code catalog; implement `--fail-on-warnings` behavior; full `ApplicationRunner` pipeline (T016)
 
 ## Milestone Map
 
@@ -15,7 +15,7 @@
 |-----------|------|--------|-------|
 | M0 | Repo bootstrap and packaging skeleton | Done | All acceptance criteria verified: build, test, pack, tool install |
 | M1 | Core reuse extraction (CodeModel/Metadata) | Done | All acceptance criteria verified: build 0 errors, CodeModel 102/102, TypeMapping 71/71, zero VS refs |
-| M2 | CLI contract, diagnostics, and configuration precedence | Not started | |
+| M2 | CLI contract, diagnostics, and configuration precedence | In progress | T013 done: `generate` parser, `ApplicationRunner`/`IDiagnosticReporter`/`GenerateCommandOptions` stubs |
 | M3 | MSBuild loading: `.csproj` and restore pipeline | Not started | |
 | M4 | MSBuild loading: `.sln` and `.slnx` | Not started | |
 | M5 | Semantic model extraction parity | Not started | |
@@ -48,6 +48,7 @@
 | T010 Add/update unit tests for M1 ported code (#43) | M1 | Executor | Done | [T010-addupdate-unit-tests-for-m1.md](.ai/tasks/T010-addupdate-unit-tests-for-m1.md) — TypeMappingTests (CamelCase, GetTypeScriptName, GetOriginalName, IsPrimitive), CollectionTests (ItemCollectionImpl, ClassCollectionImpl, EnumCollectionImpl, FieldCollectionImpl), RoslynExtensionsTests (GetName, GetFullName, GetNamespace, GetFullTypeName); added Microsoft.CodeAnalysis.CSharp package ref to test project |
 | T011 Run M1 acceptance criteria (#44) | M1 | Executor | Done | [T011-run-m1-acceptance-criteria.md](.ai/tasks/T011-run-m1-acceptance-criteria.md) — build 0 errors; CodeModel 102/102; TypeMapping 71/71; zero VS refs confirmed; origin/ unchanged |
 | T012 Update .ai/progress.md for M1 (#45) | M1 | Executor | Done | progress.md updated: M1→Done, active milestone→M2, D-0004/D-0005 added, 3 new patterns added |
+| T013 Implement generate command parser (#60) | M2 | Executor | Done | [T013-implement-generate-command-parse.md](.ai/tasks/T013-implement-generate-command-parse.md) — `Program.cs` rewrite with `System.CommandLine` 2.0.0-beta4; `GenerateCommandOptions`, `IDiagnosticReporter`, `ApplicationRunner` stubs; `ConsoleDiagnosticReporter`; build 0 errors/warnings |
 
 ## Decisions
 

--- a/.ai/tasks/T013-implement-generate-command-parse.md
+++ b/.ai/tasks/T013-implement-generate-command-parse.md
@@ -1,0 +1,41 @@
+# T013: Implement generate command parser
+- Milestone: M2
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Rewrite `src/Typewriter.Cli/Program.cs` to define the full `generate <templates>` subcommand using `System.CommandLine` 2.x prerelease, wiring all required options and delegating to `ApplicationRunner`.
+
+## Approach
+1. Added `System.CommandLine 2.0.0-beta4.22272.1` to `Typewriter.Cli.csproj`.
+2. Created stubs in `Typewriter.Application` needed by the CLI:
+   - `GenerateCommandOptions` — DTO carrying all parsed option values.
+   - `IDiagnosticReporter` — interface for MSBuild-compatible diagnostic output.
+   - `ApplicationRunner` — stub orchestrator (full impl deferred to T016).
+3. Rewrote `Program.cs` using top-level statements with `CommandLineBuilder.UseDefaults()` and a pre-invoke parse-error intercept that maps errors to exit code 2.
+4. Added `ConsoleDiagnosticReporter` in `Typewriter.Cli` as the console-backed `IDiagnosticReporter`.
+
+## Journey
+### 2026-03-02
+- Explored codebase: `Program.cs` was a one-liner (`return 0;`); `Typewriter.Application` had only a placeholder class.
+- Chose `System.CommandLine 2.0.0-beta4.22272.1` (prerelease 2.x, framework-independent, targets `netstandard2.0`).
+- `ConsoleDiagnosticReporter` placed in `Typewriter.Cli` namespace. Initial build failed because top-level `Program.cs` (global namespace) couldn't find it — fixed by adding `using Typewriter.Cli;`.
+- Final build: 0 errors, 0 warnings. All 103 unit tests pass.
+
+## Outcome
+Files changed:
+- `src/Typewriter.Cli/Typewriter.Cli.csproj` — added `System.CommandLine` package ref
+- `src/Typewriter.Cli/Program.cs` — full rewrite
+- `src/Typewriter.Cli/ConsoleDiagnosticReporter.cs` — new
+- `src/Typewriter.Application/GenerateCommandOptions.cs` — new
+- `src/Typewriter.Application/IDiagnosticReporter.cs` — new
+- `src/Typewriter.Application/ApplicationRunner.cs` — new (stub)
+
+Build: `dotnet build -c Release` → 0 errors, 0 warnings.
+Tests: 103/103 passed.
+
+## Follow-ups
+- T016: Full `ApplicationRunner` implementation (load → metadata → render → write pipeline).
+- M2 remaining: `typewriter.json` loader/precedence merge; `--fail-on-warnings` behavior; `TW` code catalog.

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -1,0 +1,20 @@
+namespace Typewriter.Application;
+
+/// <summary>
+/// Orchestrates the generate pipeline. Stub — full implementation in T016.
+/// </summary>
+public sealed class ApplicationRunner
+{
+    /// <summary>
+    /// Runs the generation pipeline and returns an exit code.
+    /// </summary>
+    /// <returns>0 success, 1 generation/runtime error, 3 SDK/restore/load error.</returns>
+    public Task<int> RunAsync(
+        GenerateCommandOptions options,
+        IDiagnosticReporter reporter,
+        CancellationToken cancellationToken = default)
+    {
+        // Stub: full implementation in T016.
+        return Task.FromResult(0);
+    }
+}

--- a/src/Typewriter.Application/GenerateCommandOptions.cs
+++ b/src/Typewriter.Application/GenerateCommandOptions.cs
@@ -1,0 +1,16 @@
+namespace Typewriter.Application;
+
+/// <summary>Options parsed from the <c>generate</c> CLI subcommand.</summary>
+public sealed class GenerateCommandOptions
+{
+    public required IReadOnlyList<string> Templates { get; init; }
+    public string? Solution { get; init; }
+    public string? Project { get; init; }
+    public string? Framework { get; init; }
+    public string? Configuration { get; init; }
+    public string? Runtime { get; init; }
+    public bool Restore { get; init; }
+    public string? Output { get; init; }
+    public string? Verbosity { get; init; }
+    public bool FailOnWarnings { get; init; }
+}

--- a/src/Typewriter.Application/IDiagnosticReporter.cs
+++ b/src/Typewriter.Application/IDiagnosticReporter.cs
@@ -1,0 +1,13 @@
+namespace Typewriter.Application;
+
+/// <summary>
+/// Emits parseable MSBuild-compatible diagnostics. Never throws; accumulates state.
+/// </summary>
+public interface IDiagnosticReporter
+{
+    void ReportError(string code, string message, string? file = null, int? line = null, int? column = null);
+    void ReportWarning(string code, string message, string? file = null, int? line = null, int? column = null);
+    void ReportInfo(string message);
+    bool HasErrors { get; }
+    bool HasWarnings { get; }
+}

--- a/src/Typewriter.Cli/ConsoleDiagnosticReporter.cs
+++ b/src/Typewriter.Cli/ConsoleDiagnosticReporter.cs
@@ -1,0 +1,38 @@
+using Typewriter.Application;
+
+namespace Typewriter.Cli;
+
+internal sealed class ConsoleDiagnosticReporter : IDiagnosticReporter
+{
+    private bool _hasErrors;
+    private bool _hasWarnings;
+
+    public bool HasErrors => _hasErrors;
+    public bool HasWarnings => _hasWarnings;
+
+    public void ReportError(string code, string message, string? file = null, int? line = null, int? column = null)
+    {
+        _hasErrors = true;
+        Console.Error.WriteLine(FormatDiagnostic("error", code, message, file, line, column));
+    }
+
+    public void ReportWarning(string code, string message, string? file = null, int? line = null, int? column = null)
+    {
+        _hasWarnings = true;
+        Console.Error.WriteLine(FormatDiagnostic("warning", code, message, file, line, column));
+    }
+
+    public void ReportInfo(string message) => Console.WriteLine(message);
+
+    private static string FormatDiagnostic(
+        string severity, string code, string message,
+        string? file, int? line, int? column)
+    {
+        var location = file is null ? string.Empty
+            : line is null ? $"{file}: "
+            : column is null ? $"{file}({line}): "
+            : $"{file}({line},{column}): ";
+
+        return $"{location}{severity} {code}: {message}";
+    }
+}

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -1,1 +1,78 @@
-return 0;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using Typewriter.Application;
+using Typewriter.Cli;
+
+var rootCommand = new RootCommand("typewriter-cli \u2014 standalone Typewriter code generator");
+
+// ---- generate subcommand ----
+var generateCommand = new Command("generate", "Generate TypeScript files from .tst templates");
+
+var templatesArg = new Argument<string[]>("templates", "One or more glob patterns for template files (.tst)")
+{
+    Arity = ArgumentArity.OneOrMore,
+};
+
+var solutionOpt      = new Option<string?>("--solution",         "Path to the .sln, .slnx, or project file");
+var projectOpt       = new Option<string?>("--project",          "Path to a specific .csproj to scope the run");
+var frameworkOpt     = new Option<string?>("--framework",        "Target framework moniker (TFM) to select");
+var configurationOpt = new Option<string?>("--configuration",    "MSBuild configuration (e.g. Debug, Release)");
+var runtimeOpt       = new Option<string?>("--runtime",          "Runtime identifier (RID) for restore/build");
+var restoreOpt       = new Option<bool>   ("--restore",          "Run dotnet restore before loading");
+var outputOpt        = new Option<string?>("--output",           "Override default output directory for generated files");
+var verbosityOpt     = new Option<string?>("--verbosity",        "Diagnostic verbosity: quiet|minimal|normal|detailed|diagnostic");
+var failOnWarningsOpt = new Option<bool>  ("--fail-on-warnings", "Exit with code 1 when warnings are emitted");
+
+generateCommand.AddArgument(templatesArg);
+generateCommand.AddOption(solutionOpt);
+generateCommand.AddOption(projectOpt);
+generateCommand.AddOption(frameworkOpt);
+generateCommand.AddOption(configurationOpt);
+generateCommand.AddOption(runtimeOpt);
+generateCommand.AddOption(restoreOpt);
+generateCommand.AddOption(outputOpt);
+generateCommand.AddOption(verbosityOpt);
+generateCommand.AddOption(failOnWarningsOpt);
+
+generateCommand.SetHandler(async (InvocationContext ctx) =>
+{
+    var pr = ctx.ParseResult;
+    var options = new GenerateCommandOptions
+    {
+        Templates      = pr.GetValueForArgument(templatesArg),
+        Solution       = pr.GetValueForOption(solutionOpt),
+        Project        = pr.GetValueForOption(projectOpt),
+        Framework      = pr.GetValueForOption(frameworkOpt),
+        Configuration  = pr.GetValueForOption(configurationOpt),
+        Runtime        = pr.GetValueForOption(runtimeOpt),
+        Restore        = pr.GetValueForOption(restoreOpt),
+        Output         = pr.GetValueForOption(outputOpt),
+        Verbosity      = pr.GetValueForOption(verbosityOpt),
+        FailOnWarnings = pr.GetValueForOption(failOnWarningsOpt),
+    };
+
+    var reporter = new ConsoleDiagnosticReporter();
+    var runner = new ApplicationRunner();
+    ctx.ExitCode = await runner.RunAsync(options, reporter, ctx.GetCancellationToken());
+});
+
+rootCommand.AddCommand(generateCommand);
+
+// ---- parse and invoke ----
+// Build the parser with defaults (--help, --version, parse-error reporting).
+var parser = new CommandLineBuilder(rootCommand)
+    .UseDefaults()
+    .Build();
+
+// Map parse errors to exit code 2 before System.CommandLine's default (exit 1).
+var parseResult = parser.Parse(args);
+if (parseResult.Errors.Count > 0)
+{
+    foreach (var error in parseResult.Errors)
+        Console.Error.WriteLine(error.Message);
+    return 2;
+}
+
+return await parser.InvokeAsync(args);

--- a/src/Typewriter.Cli/Typewriter.Cli.csproj
+++ b/src/Typewriter.Cli/Typewriter.Cli.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Typewriter.Application\Typewriter.Application.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Add `System.CommandLine 2.0.0-beta4.22272.1` package reference to `Typewriter.Cli.csproj`
- Rewrite `Program.cs` with a full `generate <templates>` subcommand wired via `CommandLineBuilder.UseDefaults()`; parse errors intercepted before `InvokeAsync` and mapped to exit code 2
- Options: `--solution`, `--project`, `--framework`, `--configuration`, `--runtime`, `--restore`, `--output`, `--verbosity`, `--fail-on-warnings`
- Add stubs to `Typewriter.Application`: `GenerateCommandOptions` (DTO), `IDiagnosticReporter` (interface), `ApplicationRunner` (stub — full impl in T016)
- Add `ConsoleDiagnosticReporter` to `Typewriter.Cli` (MSBuild-compatible console sink)

## Test plan

- [x] `dotnet restore` — succeeded, all 11 projects
- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] `dotnet test -c Release` — 103/103 tests pass
- [ ] `typewriter-cli generate` (no templates) → exit code 2 (parse error)
- [ ] `typewriter-cli generate **/*.tst --help` → exit code 0, prints usage

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)