### PR TITLE
feat: implement typewriter.json loader and precedence merge (T015)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T014)
+> Last touched: 2026-03-02 by Claude (Executor, T015)
 
 ## Current State
 
 - **Active milestone**: M2 - CLI contract, diagnostics, and configuration precedence
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Implement `typewriter.json` loader and precedence merge; implement `--fail-on-warnings` behavior; full `ApplicationRunner` pipeline (T016)
+- **Next step**: Implement `--fail-on-warnings` behavior and full `ApplicationRunner` pipeline (T016)
 
 ## Milestone Map
 
@@ -15,7 +15,7 @@
 |-----------|------|--------|-------|
 | M0 | Repo bootstrap and packaging skeleton | Done | All acceptance criteria verified: build, test, pack, tool install |
 | M1 | Core reuse extraction (CodeModel/Metadata) | Done | All acceptance criteria verified: build 0 errors, CodeModel 102/102, TypeMapping 71/71, zero VS refs |
-| M2 | CLI contract, diagnostics, and configuration precedence | In progress | T013 done: `generate` parser, stubs; T014 done: `Diagnostics/` infrastructure, `MsBuildDiagnosticReporter`, TW code catalog |
+| M2 | CLI contract, diagnostics, and configuration precedence | In progress | T013 done: `generate` parser, stubs; T014 done: `Diagnostics/` infrastructure, `MsBuildDiagnosticReporter`, TW code catalog; T015 done: `typewriter.json` loader, `GenerateCommandOptions` record with `Merge()` |
 | M3 | MSBuild loading: `.csproj` and restore pipeline | Not started | |
 | M4 | MSBuild loading: `.sln` and `.slnx` | Not started | |
 | M5 | Semantic model extraction parity | Not started | |
@@ -50,6 +50,7 @@
 | T012 Update .ai/progress.md for M1 (#45) | M1 | Executor | Done | progress.md updated: M1→Done, active milestone→M2, D-0004/D-0005 added, 3 new patterns added |
 | T013 Implement generate command parser (#60) | M2 | Executor | Done | [T013-implement-generate-command-parse.md](.ai/tasks/T013-implement-generate-command-parse.md) — `Program.cs` rewrite with `System.CommandLine` 2.0.0-beta4; `GenerateCommandOptions`, `IDiagnosticReporter`, `ApplicationRunner` stubs; `ConsoleDiagnosticReporter`; build 0 errors/warnings |
 | T014 IDiagnosticReporter + TW code catalog (#61) | M2 | Executor | Done | [T014-implement-idiagnosticreporter-and-tw-code-catalog.md](.ai/tasks/T014-implement-idiagnosticreporter-and-tw-code-catalog.md) — `Diagnostics/` folder: severity enum, code constants, message record, interface, `MsBuildDiagnosticReporter`; 8 new tests; build 0 errors/warnings |
+| T015 typewriter.json loader + precedence merge (#62) | M2 | Executor | Done | [T015-implement-typewriterjson-loader.md](.ai/tasks/T015-implement-typewriterjson-loader.md) — `Configuration/TypewriterConfig.cs`, `TypewriterConfigLoader.cs`; `GenerateCommandOptions` → record + `Merge()`; 8 new tests; build 0 errors/warnings |
 
 ## Decisions
 

--- a/.ai/tasks/T015-implement-typewriterjson-loader.md
+++ b/.ai/tasks/T015-implement-typewriterjson-loader.md
@@ -1,0 +1,45 @@
+# T015: Implement typewriter.json loader and precedence merge
+- Milestone: M2
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Create the configuration loading and merging layer in `src/Typewriter.Application/Configuration/`:
+a POCO matching `typewriter.json`, an upward-walking loader, and a precedence-merge resolver
+that produces `GenerateCommandOptions`.
+
+## Approach
+1. `TypewriterConfig.cs` — nullable POCO with all fields from the `typewriter.json` schema.
+2. `TypewriterConfigLoader.cs` — static loader using `System.Text.Json`; walks upward from a
+   start directory, stops at first `typewriter.json` found or at `.git` boundary.
+3. `GenerateCommandOptions.cs` — converted from sealed class to immutable positional record;
+   added `static Merge(TypewriterConfig? config, …)` with CLI > config > default precedence.
+4. `Program.cs` — updated to call `GenerateCommandOptions.Merge(null, …)` (config integration
+   deferred to T016 ApplicationRunner).
+5. `ConfigurationPrecedenceTests.cs` — 8 tests covering all merge branches and loader scenarios.
+
+## Journey
+### 2026-03-02
+- Created `src/Typewriter.Application/Configuration/` directory.
+- Wrote `TypewriterConfig.cs` with 9 nullable properties matching the schema.
+- Wrote `TypewriterConfigLoader.cs`; walks `DirectoryInfo.Parent` chain, checks for
+  `typewriter.json` first, then `.git` boundary, then continues upward.
+- Rewrote `GenerateCommandOptions.cs` as a positional record; `Verbosity` promoted from
+  `string?` to `string` (defaults to `"normal"`). Added `Merge()` static factory.
+- Updated `Program.cs` handler to call `GenerateCommandOptions.Merge(config: null, …)`.
+- Added 8 tests in `tests/Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs`.
+- `dotnet build -c Release` → 0 errors, 0 warnings.
+- `dotnet test -c Release` → 124/124 passed (UnitTests), all other suites green.
+
+## Outcome
+All files created, build clean, all tests green.
+- `src/Typewriter.Application/Configuration/TypewriterConfig.cs`
+- `src/Typewriter.Application/Configuration/TypewriterConfigLoader.cs`
+- `src/Typewriter.Application/GenerateCommandOptions.cs` (updated)
+- `src/Typewriter.Cli/Program.cs` (updated)
+- `tests/Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs`
+
+## Follow-ups
+- T016: Wire `TypewriterConfigLoader.Load()` into `ApplicationRunner` pipeline.

--- a/src/Typewriter.Application/Configuration/TypewriterConfig.cs
+++ b/src/Typewriter.Application/Configuration/TypewriterConfig.cs
@@ -1,0 +1,15 @@
+namespace Typewriter.Application.Configuration;
+
+/// <summary>POCO that maps to the <c>typewriter.json</c> configuration file schema.</summary>
+public class TypewriterConfig
+{
+    public string? TemplatesGlob { get; set; }
+    public string? Solution { get; set; }
+    public string? Project { get; set; }
+    public string? Framework { get; set; }
+    public string? Configuration { get; set; }
+    public string? Runtime { get; set; }
+    public string? Output { get; set; }
+    public string? Verbosity { get; set; }
+    public bool? FailOnWarnings { get; set; }
+}

--- a/src/Typewriter.Application/Configuration/TypewriterConfigLoader.cs
+++ b/src/Typewriter.Application/Configuration/TypewriterConfigLoader.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace Typewriter.Application.Configuration;
+
+/// <summary>
+/// Locates and deserializes the nearest <c>typewriter.json</c> by walking upward
+/// from a starting directory until the file is found or a <c>.git</c> boundary is reached.
+/// </summary>
+public static class TypewriterConfigLoader
+{
+    private const string ConfigFileName = "typewriter.json";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Walks upward from <paramref name="startDirectory"/> looking for <c>typewriter.json</c>.
+    /// Stops at the first file found or when a <c>.git</c> directory is encountered (repo root).
+    /// </summary>
+    /// <param name="startDirectory">Directory to begin the upward search from.</param>
+    /// <returns>Deserialized <see cref="TypewriterConfig"/>, or <c>null</c> if not found.</returns>
+    public static TypewriterConfig? Load(string startDirectory)
+    {
+        var current = new DirectoryInfo(startDirectory);
+
+        while (current is not null)
+        {
+            var configFile = Path.Combine(current.FullName, ConfigFileName);
+            if (File.Exists(configFile))
+            {
+                return Deserialize(configFile);
+            }
+
+            // Stop at repo root boundary.
+            if (Directory.Exists(Path.Combine(current.FullName, ".git")))
+            {
+                break;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static TypewriterConfig? Deserialize(string filePath)
+    {
+        var json = File.ReadAllText(filePath);
+        return JsonSerializer.Deserialize<TypewriterConfig>(json, _jsonOptions);
+    }
+}

--- a/src/Typewriter.Application/GenerateCommandOptions.cs
+++ b/src/Typewriter.Application/GenerateCommandOptions.cs
@@ -1,16 +1,52 @@
+using Typewriter.Application.Configuration;
+
 namespace Typewriter.Application;
 
-/// <summary>Options parsed from the <c>generate</c> CLI subcommand.</summary>
-public sealed class GenerateCommandOptions
+/// <summary>Fully-resolved, immutable options for a single <c>generate</c> command invocation.</summary>
+/// <remarks>
+/// Construct via <see cref="Merge"/> so that CLI args, config file, and defaults are applied
+/// in the correct precedence order: CLI args &gt; config file &gt; defaults.
+/// </remarks>
+public record GenerateCommandOptions(
+    IReadOnlyList<string> Templates,
+    string? Solution,
+    string? Project,
+    string? Framework,
+    string? Configuration,
+    string? Runtime,
+    bool Restore,
+    string? Output,
+    string Verbosity,
+    bool FailOnWarnings)
 {
-    public required IReadOnlyList<string> Templates { get; init; }
-    public string? Solution { get; init; }
-    public string? Project { get; init; }
-    public string? Framework { get; init; }
-    public string? Configuration { get; init; }
-    public string? Runtime { get; init; }
-    public bool Restore { get; init; }
-    public string? Output { get; init; }
-    public string? Verbosity { get; init; }
-    public bool FailOnWarnings { get; init; }
+    /// <summary>
+    /// Merges CLI arguments, an optional config file, and defaults into a
+    /// <see cref="GenerateCommandOptions"/> instance.
+    /// </summary>
+    /// <remarks>Precedence: CLI args &gt; config file &gt; defaults.</remarks>
+    public static GenerateCommandOptions Merge(
+        TypewriterConfig? config,
+        IReadOnlyList<string> templates,
+        string? solution,
+        string? project,
+        string? framework,
+        string? configuration,
+        string? runtime,
+        bool restore,
+        string? output,
+        string? verbosity,
+        bool failOnWarnings)
+    {
+        return new GenerateCommandOptions(
+            Templates:      templates,
+            Solution:       solution       ?? config?.Solution,
+            Project:        project        ?? config?.Project,
+            Framework:      framework      ?? config?.Framework,
+            Configuration:  configuration  ?? config?.Configuration,
+            Runtime:        runtime        ?? config?.Runtime,
+            Restore:        restore,
+            Output:         output         ?? config?.Output,
+            Verbosity:      verbosity      ?? config?.Verbosity ?? "normal",
+            FailOnWarnings: failOnWarnings || (config?.FailOnWarnings ?? false));
+    }
 }

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -39,19 +39,18 @@ generateCommand.AddOption(failOnWarningsOpt);
 generateCommand.SetHandler(async (InvocationContext ctx) =>
 {
     var pr = ctx.ParseResult;
-    var options = new GenerateCommandOptions
-    {
-        Templates      = pr.GetValueForArgument(templatesArg),
-        Solution       = pr.GetValueForOption(solutionOpt),
-        Project        = pr.GetValueForOption(projectOpt),
-        Framework      = pr.GetValueForOption(frameworkOpt),
-        Configuration  = pr.GetValueForOption(configurationOpt),
-        Runtime        = pr.GetValueForOption(runtimeOpt),
-        Restore        = pr.GetValueForOption(restoreOpt),
-        Output         = pr.GetValueForOption(outputOpt),
-        Verbosity      = pr.GetValueForOption(verbosityOpt),
-        FailOnWarnings = pr.GetValueForOption(failOnWarningsOpt),
-    };
+    var options = GenerateCommandOptions.Merge(
+        config:        null, // typewriter.json loaded by ApplicationRunner (T016)
+        templates:     pr.GetValueForArgument(templatesArg),
+        solution:      pr.GetValueForOption(solutionOpt),
+        project:       pr.GetValueForOption(projectOpt),
+        framework:     pr.GetValueForOption(frameworkOpt),
+        configuration: pr.GetValueForOption(configurationOpt),
+        runtime:       pr.GetValueForOption(runtimeOpt),
+        restore:       pr.GetValueForOption(restoreOpt),
+        output:        pr.GetValueForOption(outputOpt),
+        verbosity:     pr.GetValueForOption(verbosityOpt),
+        failOnWarnings: pr.GetValueForOption(failOnWarningsOpt));
 
     var reporter = new MsBuildDiagnosticReporter();
     var runner = new ApplicationRunner();

--- a/tests/Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs
+++ b/tests/Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using Typewriter.Application;
+using Typewriter.Application.Configuration;
+using Xunit;
+
+namespace Typewriter.UnitTests.Configuration;
+
+public class ConfigurationPrecedenceTests
+{
+    // ---- Merge: CLI overrides ----
+
+    [Fact]
+    public void CliOverridesConfigAndTemplate()
+    {
+        var config = new TypewriterConfig { Framework = "net8.0" };
+
+        var result = GenerateCommandOptions.Merge(
+            config:        config,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     "net10.0",
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        Assert.Equal("net10.0", result.Framework);
+    }
+
+    [Fact]
+    public void ConfigFallsBackWhenCliIsNull()
+    {
+        var config = new TypewriterConfig { Framework = "net8.0" };
+
+        var result = GenerateCommandOptions.Merge(
+            config:        config,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        Assert.Equal("net8.0", result.Framework);
+    }
+
+    [Fact]
+    public void DefaultVerbosityIsNormal()
+    {
+        var result = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        Assert.Equal("normal", result.Verbosity);
+    }
+
+    [Fact]
+    public void CliVerbosityOverridesConfigAndDefault()
+    {
+        var config = new TypewriterConfig { Verbosity = "quiet" };
+
+        var result = GenerateCommandOptions.Merge(
+            config:        config,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     "detailed",
+            failOnWarnings: false);
+
+        Assert.Equal("detailed", result.Verbosity);
+    }
+
+    [Fact]
+    public void ConfigVerbosityUsedWhenCliIsNull()
+    {
+        var config = new TypewriterConfig { Verbosity = "minimal" };
+
+        var result = GenerateCommandOptions.Merge(
+            config:        config,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        Assert.Equal("minimal", result.Verbosity);
+    }
+
+    [Fact]
+    public void FailOnWarnings_ConfigTrueIsPreservedWhenCliFalse()
+    {
+        var config = new TypewriterConfig { FailOnWarnings = true };
+
+        var result = GenerateCommandOptions.Merge(
+            config:        config,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        Assert.True(result.FailOnWarnings);
+    }
+
+    [Fact]
+    public void FailOnWarnings_CliTrueOverridesConfigFalse()
+    {
+        var config = new TypewriterConfig { FailOnWarnings = false };
+
+        var result = GenerateCommandOptions.Merge(
+            config:        config,
+            templates:     ["tmpl.tst"],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: true);
+
+        Assert.True(result.FailOnWarnings);
+    }
+
+    [Fact]
+    public void NullConfig_AllFieldsUseCliOrDefault()
+    {
+        var result = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     ["a.tst", "b.tst"],
+            solution:      "my.sln",
+            project:       null,
+            framework:     "net9.0",
+            configuration: "Release",
+            runtime:       "linux-x64",
+            restore:       true,
+            output:        "./out",
+            verbosity:     "quiet",
+            failOnWarnings: true);
+
+        Assert.Equal(new[] { "a.tst", "b.tst" }, result.Templates);
+        Assert.Equal("my.sln",    result.Solution);
+        Assert.Null(result.Project);
+        Assert.Equal("net9.0",    result.Framework);
+        Assert.Equal("Release",   result.Configuration);
+        Assert.Equal("linux-x64", result.Runtime);
+        Assert.True(result.Restore);
+        Assert.Equal("./out",     result.Output);
+        Assert.Equal("quiet",     result.Verbosity);
+        Assert.True(result.FailOnWarnings);
+    }
+
+    // ---- TypewriterConfigLoader ----
+
+    [Fact]
+    public void Loader_ReturnsNull_WhenNoConfigFileExists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        // Place a .git sentinel so the walker stops here instead of going further.
+        Directory.CreateDirectory(Path.Combine(tempDir, ".git"));
+        try
+        {
+            var result = TypewriterConfigLoader.Load(tempDir);
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Loader_ReturnsConfig_WhenFileExistsInStartDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Directory.CreateDirectory(Path.Combine(tempDir, ".git"));
+
+        var json = """{"framework": "net8.0", "verbosity": "quiet"}""";
+        File.WriteAllText(Path.Combine(tempDir, "typewriter.json"), json);
+        try
+        {
+            var result = TypewriterConfigLoader.Load(tempDir);
+            Assert.NotNull(result);
+            Assert.Equal("net8.0", result.Framework);
+            Assert.Equal("quiet",  result.Verbosity);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Loader_FindsConfigInAncestorDirectory()
+    {
+        var root    = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var subDir  = Path.Combine(root, "src", "templates");
+        Directory.CreateDirectory(subDir);
+        Directory.CreateDirectory(Path.Combine(root, ".git"));
+
+        var json = """{"solution": "ancestor.sln"}""";
+        File.WriteAllText(Path.Combine(root, "typewriter.json"), json);
+        try
+        {
+            var result = TypewriterConfigLoader.Load(subDir);
+            Assert.NotNull(result);
+            Assert.Equal("ancestor.sln", result.Solution);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Loader_ParsesPartialConfig_LeavingMissingFieldsNull()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Directory.CreateDirectory(Path.Combine(tempDir, ".git"));
+
+        // Only "project" is present; all other fields must stay null.
+        var json = """{"project": "MyApp.csproj"}""";
+        File.WriteAllText(Path.Combine(tempDir, "typewriter.json"), json);
+        try
+        {
+            var result = TypewriterConfigLoader.Load(tempDir);
+            Assert.NotNull(result);
+            Assert.Equal("MyApp.csproj", result.Project);
+            Assert.Null(result.Framework);
+            Assert.Null(result.Solution);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Loader_ThrowsOrReturnsNull_OnMalformedJson()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Directory.CreateDirectory(Path.Combine(tempDir, ".git"));
+
+        File.WriteAllText(Path.Combine(tempDir, "typewriter.json"), "{ not valid json");
+        try
+        {
+            // Malformed JSON surfaces a JsonException (per task spec: "surface exception or return null").
+            Assert.Throws<JsonException>(() => TypewriterConfigLoader.Load(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TypewriterConfig.cs`: nullable POCO matching `typewriter.json` schema (9 fields)
- Add `TypewriterConfigLoader.cs`: static upward-walking discovery using `System.Text.Json`; stops at `.git` boundary or when `typewriter.json` is found
- Convert `GenerateCommandOptions` from sealed class to immutable positional record with `static Merge(TypewriterConfig? config, …)` — precedence: CLI > config file > defaults (default verbosity = `"normal"`)
- Update `Program.cs` to call `GenerateCommandOptions.Merge(config: null, …)` (config file wired in T016)
- Add 8 `ConfigurationPrecedenceTests` covering all `Merge` branches and loader scenarios

## Test plan

- [x] `CliOverridesConfigAndTemplate` passes (acceptance criterion)
- [x] `ConfigFallsBackWhenCliIsNull` — config field used when CLI arg is null
- [x] `DefaultVerbosityIsNormal` — fallback when both CLI and config omit verbosity
- [x] `FailOnWarnings` OR semantics (true from either source)
- [x] Loader: file not found → `null`
- [x] Loader: file in start directory → deserialized
- [x] Loader: file in ancestor directory → found and deserialized
- [x] Loader: partial config → missing fields remain `null`
- [x] Loader: malformed JSON → `JsonException` surfaced
- [x] Build: 0 errors, 0 warnings
- [x] All 124 unit tests pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)