### PR TITLE
feat: implement ApplicationRunner validation stub and exit-code mapping (T016)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T015)
+> Last touched: 2026-03-02 by Claude (Executor, T016)
 
 ## Current State
 
 - **Active milestone**: M2 - CLI contract, diagnostics, and configuration precedence
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Implement `--fail-on-warnings` behavior and full `ApplicationRunner` pipeline (T016)
+- **Next step**: Begin M3 — MSBuild project loading pipeline (T017+)
 
 ## Milestone Map
 
@@ -15,7 +15,7 @@
 |-----------|------|--------|-------|
 | M0 | Repo bootstrap and packaging skeleton | Done | All acceptance criteria verified: build, test, pack, tool install |
 | M1 | Core reuse extraction (CodeModel/Metadata) | Done | All acceptance criteria verified: build 0 errors, CodeModel 102/102, TypeMapping 71/71, zero VS refs |
-| M2 | CLI contract, diagnostics, and configuration precedence | In progress | T013 done: `generate` parser, stubs; T014 done: `Diagnostics/` infrastructure, `MsBuildDiagnosticReporter`, TW code catalog; T015 done: `typewriter.json` loader, `GenerateCommandOptions` record with `Merge()` |
+| M2 | CLI contract, diagnostics, and configuration precedence | Done | T013–T016 done: CLI parser, diagnostics infrastructure, config loader, ApplicationRunner validation stub with exit-code mapping |
 | M3 | MSBuild loading: `.csproj` and restore pipeline | Not started | |
 | M4 | MSBuild loading: `.sln` and `.slnx` | Not started | |
 | M5 | Semantic model extraction parity | Not started | |
@@ -51,6 +51,7 @@
 | T013 Implement generate command parser (#60) | M2 | Executor | Done | [T013-implement-generate-command-parse.md](.ai/tasks/T013-implement-generate-command-parse.md) — `Program.cs` rewrite with `System.CommandLine` 2.0.0-beta4; `GenerateCommandOptions`, `IDiagnosticReporter`, `ApplicationRunner` stubs; `ConsoleDiagnosticReporter`; build 0 errors/warnings |
 | T014 IDiagnosticReporter + TW code catalog (#61) | M2 | Executor | Done | [T014-implement-idiagnosticreporter-and-tw-code-catalog.md](.ai/tasks/T014-implement-idiagnosticreporter-and-tw-code-catalog.md) — `Diagnostics/` folder: severity enum, code constants, message record, interface, `MsBuildDiagnosticReporter`; 8 new tests; build 0 errors/warnings |
 | T015 typewriter.json loader + precedence merge (#62) | M2 | Executor | Done | [T015-implement-typewriterjson-loader.md](.ai/tasks/T015-implement-typewriterjson-loader.md) — `Configuration/TypewriterConfig.cs`, `TypewriterConfigLoader.cs`; `GenerateCommandOptions` → record + `Merge()`; 8 new tests; build 0 errors/warnings |
+| T016 Wire --fail-on-warnings and exit-code mapping (#63) | M2 | Executor | Done | `ApplicationRunner.cs` validation stub: empty-templates check, TW1002 for missing solution/project, FailOnWarnings→exit 1; `Placeholder.cs` deleted; 2 new `CliContractTests`; build 0 errors/warnings, 129 tests pass |
 
 ## Decisions
 

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -3,20 +3,39 @@ using Typewriter.Application.Diagnostics;
 namespace Typewriter.Application;
 
 /// <summary>
-/// Orchestrates the generate pipeline. Stub — full implementation in T016.
+/// Orchestrates the generate pipeline. M2 stub — validates inputs only; generation logic added in M3+.
 /// </summary>
 public sealed class ApplicationRunner
 {
     /// <summary>
-    /// Runs the generation pipeline and returns an exit code.
+    /// Validates inputs and returns an exit code.
     /// </summary>
-    /// <returns>0 success, 1 generation/runtime error, 3 SDK/restore/load error.</returns>
+    /// <returns>
+    /// 0 — success;
+    /// 1 — warnings elevated to errors (<see cref="GenerateCommandOptions.FailOnWarnings"/> is true and warnings exist);
+    /// 2 — argument/input errors (empty templates, missing solution/project);
+    /// 3 — SDK/restore/load/build errors (reserved; not triggered in M2 stub).
+    /// </returns>
     public Task<int> RunAsync(
         GenerateCommandOptions options,
         IDiagnosticReporter reporter,
         CancellationToken cancellationToken = default)
     {
-        // Stub: full implementation in T016.
+        if (options.Templates == null || options.Templates.Count == 0)
+            return Task.FromResult(2);
+
+        if (string.IsNullOrWhiteSpace(options.Solution) && string.IsNullOrWhiteSpace(options.Project))
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                DiagnosticCode.TW1002,
+                "Either --solution or --project must be provided."));
+            return Task.FromResult(2);
+        }
+
+        if (options.FailOnWarnings && reporter.WarningCount > 0)
+            return Task.FromResult(1);
+
         return Task.FromResult(0);
     }
 }

--- a/src/Typewriter.Application/Placeholder.cs
+++ b/src/Typewriter.Application/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace Typewriter.Application;
-
-internal static class Placeholder { }

--- a/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
+++ b/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
@@ -1,0 +1,79 @@
+using Typewriter.Application;
+using Typewriter.Application.Diagnostics;
+using Xunit;
+
+namespace Typewriter.UnitTests.Cli;
+
+public class CliContractTests
+{
+    private sealed class FakeDiagnosticReporter : IDiagnosticReporter
+    {
+        private int _warningCount;
+        private int _errorCount;
+
+        public FakeDiagnosticReporter(int warningCount = 0, int errorCount = 0)
+        {
+            _warningCount = warningCount;
+            _errorCount = errorCount;
+        }
+
+        public void Report(DiagnosticMessage message)
+        {
+            if (message.Severity == DiagnosticSeverity.Warning) _warningCount++;
+            else if (message.Severity == DiagnosticSeverity.Error) _errorCount++;
+        }
+
+        public int WarningCount => _warningCount;
+        public int ErrorCount => _errorCount;
+    }
+
+    [Fact]
+    public async Task Generate_InvalidArgs_Returns2()
+    {
+        var runner = new ApplicationRunner();
+        var reporter = new FakeDiagnosticReporter();
+
+        // Empty templates + no solution/project → exit code 2
+        var options = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     [],
+            solution:      null,
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        Assert.Equal(2, exitCode);
+    }
+
+    [Fact]
+    public async Task Generate_WarningsWithFailFlag_Returns1()
+    {
+        var runner = new ApplicationRunner();
+        // Pre-seed the reporter with 1 warning to simulate a prior warning being reported.
+        var reporter = new FakeDiagnosticReporter(warningCount: 1);
+
+        var options = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     ["tmpl.tst"],
+            solution:      "my.sln",
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: true);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        Assert.Equal(1, exitCode);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the `ApplicationRunner` stub with validation logic per M2 requirements
- Deletes `Placeholder.cs` (superseded by `ApplicationRunner.cs`)
- Adds `CliContractTests` with the two required acceptance-criteria tests

## What changed

**`src/Typewriter.Application/ApplicationRunner.cs`** — implemented validation:
1. Empty templates list → exit code 2
2. Neither `--solution` nor `--project` provided → report `TW1002` + exit code 2
3. `FailOnWarnings` is true and `reporter.WarningCount > 0` → exit code 1
4. Otherwise → exit code 0 (no generation in M2 stub)

**`src/Typewriter.Application/Placeholder.cs`** — deleted (replaced by `ApplicationRunner.cs`)

**`tests/Typewriter.UnitTests/Cli/CliContractTests.cs`** — new tests:
- `Generate_InvalidArgs_Returns2`: empty templates + no solution/project → exit 2
- `Generate_WarningsWithFailFlag_Returns1`: `WarningCount=1`, `FailOnWarnings=true` → exit 1

## Verification

- Build: 0 errors, 0 warnings-as-errors
- Tests: 129 passed, 0 failed

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)