### PR TITLE
docs: update .ai/progress.md for M2 completion (T019)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T018)
+> Last touched: 2026-03-02 by Claude (Executor, T019)
 
 ## Current State
 
@@ -51,8 +51,8 @@
 | T013 Implement generate command parser (#60) | M2 | Executor | Done | [T013-implement-generate-command-parse.md](.ai/tasks/T013-implement-generate-command-parse.md) — `Program.cs` rewrite with `System.CommandLine` 2.0.0-beta4; `GenerateCommandOptions`, `IDiagnosticReporter`, `ApplicationRunner` stubs; `ConsoleDiagnosticReporter`; build 0 errors/warnings |
 | T014 IDiagnosticReporter + TW code catalog (#61) | M2 | Executor | Done | [T014-implement-idiagnosticreporter-and-tw-code-catalog.md](.ai/tasks/T014-implement-idiagnosticreporter-and-tw-code-catalog.md) — `Diagnostics/` folder: severity enum, code constants, message record, interface, `MsBuildDiagnosticReporter`; 8 new tests; build 0 errors/warnings |
 | T015 typewriter.json loader + precedence merge (#62) | M2 | Executor | Done | [T015-implement-typewriterjson-loader.md](.ai/tasks/T015-implement-typewriterjson-loader.md) — `Configuration/TypewriterConfig.cs`, `TypewriterConfigLoader.cs`; `GenerateCommandOptions` → record + `Merge()`; 8 new tests; build 0 errors/warnings |
-| T016 Wire --fail-on-warnings and exit-code mapping (#63) | M2 | Executor | Done | `ApplicationRunner.cs` validation stub: empty-templates check, TW1002 for missing solution/project, FailOnWarnings→exit 1; `Placeholder.cs` deleted; 2 new `CliContractTests`; build 0 errors/warnings, 129 tests pass |
-| T017 Add M2 acceptance tests (#64) | M2 | Executor | Done | Verified 4 acceptance tests already in place from T013-T016: `CliContractTests` (2), `DiagnosticFormatTests.MsBuildStyleMessage_IsParseable` (1), `ConfigurationPrecedenceTests.CliOverridesConfigAndTemplate` (1); build 0 errors/warnings, 129 tests pass |
+| T016 Wire --fail-on-warnings and exit-code mapping (#63) | M2 | Executor | Done | [T016-application-runner-stub.md](.ai/tasks/T016-application-runner-stub.md) — `ApplicationRunner.cs` validation stub: empty-templates check, TW1002 for missing solution/project, FailOnWarnings→exit 1; `Placeholder.cs` deleted; 2 new `CliContractTests`; build 0 errors/warnings, 129 tests pass |
+| T017 Add M2 acceptance tests (#64) | M2 | Executor | Done | [T017-m2-acceptance-tests.md](.ai/tasks/T017-m2-acceptance-tests.md) — Verified 4 acceptance tests already in place from T013-T016: `CliContractTests` (2), `DiagnosticFormatTests.MsBuildStyleMessage_IsParseable` (1), `ConfigurationPrecedenceTests.CliOverridesConfigAndTemplate` (1); build 0 errors/warnings, 129 tests pass |
 | T018 Run M2 acceptance criteria (#65) | M2 | Executor | Done | [T018-run-m2-acceptance-criteria.md](.ai/tasks/T018-run-m2-acceptance-criteria.md) — restore/build/test all pass; 129/129 tests pass; origin/ unchanged; zero VS coupling in M2 .cs source files |
 
 ## Decisions
@@ -64,6 +64,8 @@
 | D-0003 | Loading architecture: `ProjectGraph` + Roslyn workspace hybrid | 2026-02-19 | See `_archive/.ai_CLAUDE/decisions/D-0003-project-loading-strategy.md` |
 | D-0004 | `PartialRenderingMode.cs` moved from `Typewriter.CodeModel` to `Typewriter.Metadata` | 2026-03-02 | Breaks circular dependency; `namespace Typewriter.Configuration` kept for API compat. See T008. |
 | D-0005 | `ILog`/`Log` omitted from `Settings` abstract class for M1 | 2026-03-02 | Not consumed by CodeModel in M1; will be reconsidered for M2 CLI diagnostics wiring. See T007. |
+| D-0006 | `System.CommandLine` pinned to `2.0.0-beta4.22272.1` | 2026-03-02 | Prerelease 2.x targets `netstandard2.0`, provides stable API shape for the `CommandLineBuilder`+`UseDefaults()` pattern; avoids 1.x→2.x breaking API changes. See T013. |
+| D-0007 | `typewriter.json` discovery stops at `.git` boundary | 2026-03-02 | Upward-walk terminates at the first directory containing `.git/` (repo root) to prevent config files from unrelated parent repos from silently applying. See T015. |
 
 ## Open Questions
 
@@ -93,3 +95,5 @@ Note: Q1 (`IncludeProject(name)` ambiguity) was resolved — see `_archive/Q1-in
 - **Type alias disambiguation**: When `ImplicitUsings` is enabled, use `using Alias = Full.Namespace.Type;` file-scope aliases to resolve conflicts between `System.*` types (e.g., `System.Attribute`, `System.Enum`, `System.Type`) and `Typewriter.CodeModel.*` types of the same name. See T010 (CollectionTests.cs).
 - **Cross-project type moves**: When moving a type to a lower-dependency project to break a circular reference, keep the original `namespace` declaration unchanged to preserve API compatibility for consumers. See T008 (`PartialRenderingMode.cs`).
 - **Agent CI environment**: Install .NET SDK to `/tmp/dotnet` via `dotnet-install.sh` and set `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` on Linux agents without ICU libraries. See T011.
+- **ApplicationRunner stub pattern**: Implement the pipeline orchestrator as a validation-only stub in the milestone that establishes the CLI contract; defer the full load→metadata→render→write pipeline to the milestone that delivers the required dependencies. Allows acceptance tests to pass immediately. See T016.
+- **IDiagnosticReporter injection**: Pass `IDiagnosticReporter` into `RunAsync()` rather than the constructor so each invocation gets a fresh reporter; use a `FakeDiagnosticReporter` with pre-seeded counts in unit tests to verify `--fail-on-warnings` without real console output. See T016.

--- a/.ai/tasks/T016-application-runner-stub.md
+++ b/.ai/tasks/T016-application-runner-stub.md
@@ -1,0 +1,39 @@
+# T016: ApplicationRunner validation stub and exit-code mapping
+- Milestone: M2
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Implement the M2 `ApplicationRunner` stub: validate CLI inputs (templates, solution/project), emit TW1002 diagnostic for missing solution/project, honour `--fail-on-warnings`, and return the correct exit code (0/1/2/3) per the CLI contract.
+
+## Approach
+1. Rewrote `ApplicationRunner.RunAsync()` with ordered validation guards returning exit codes 0/1/2.
+2. Deleted the unused `Placeholder.cs` class from `Typewriter.Application`.
+3. Added `CliContractTests.cs` in `tests/Typewriter.UnitTests/Cli/` with a `FakeDiagnosticReporter` helper and two fact tests covering exit codes 1 and 2.
+
+Key decision: validation order is (a) empty-templates check → exit 2 before any reporter call; (b) missing solution/project → emit TW1002 error, exit 2; (c) `FailOnWarnings && reporter.WarningCount > 0` → exit 1; (d) success → exit 0.
+
+## Journey
+### 2026-03-02
+- `ApplicationRunner.cs` was a stub returning `Task.FromResult(0)` unconditionally (from T013).
+- Added guards in order: empty templates, missing solution/project (with TW1002 report), fail-on-warnings.
+- `Placeholder.cs` still present from initial project scaffold — deleted it (only had a comment).
+- Added `tests/Typewriter.UnitTests/Cli/CliContractTests.cs`:
+  - `FakeDiagnosticReporter` with seeded counts lets tests bypass real console output.
+  - `Generate_InvalidArgs_Returns2`: empty templates + no solution/project → 2.
+  - `Generate_WarningsWithFailFlag_Returns1`: 1 pre-seeded warning + failOnWarnings → 1.
+- `dotnet build -c Release` → 0 errors, 0 warnings.
+- `dotnet test -c Release` → 129/129 passed.
+
+## Outcome
+Files changed:
+- `src/Typewriter.Application/ApplicationRunner.cs` — rewritten with validation guards
+- `src/Typewriter.Application/Placeholder.cs` — deleted
+- `tests/Typewriter.UnitTests/Cli/CliContractTests.cs` — new (2 tests)
+
+Build: 0 errors, 0 warnings. Tests: 129/129 passed.
+
+## Follow-ups
+- M3: Wire `TypewriterConfigLoader.Load()` and full pipeline (load → metadata → render → write) into `ApplicationRunner`.

--- a/.ai/tasks/T017-m2-acceptance-tests.md
+++ b/.ai/tasks/T017-m2-acceptance-tests.md
@@ -1,0 +1,34 @@
+# T017: Add M2 acceptance tests
+- Milestone: M2
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Confirm the four M2 acceptance tests exist and pass in the test suite, and verify no new test files are needed beyond what T013–T016 already created.
+
+## Approach
+Audit the test projects for the four required acceptance tests; if any are missing, add them. If all are present, verify they pass and record findings.
+
+## Journey
+### 2026-03-02
+- Reviewed `tests/Typewriter.UnitTests/` after T016 completion.
+- All four required M2 acceptance tests were already in place from earlier tasks:
+  - `CliContractTests.Generate_InvalidArgs_Returns2` — created in T016
+  - `CliContractTests.Generate_WarningsWithFailFlag_Returns1` — created in T016
+  - `DiagnosticFormatTests.MsBuildStyleMessage_IsParseable` — created in T014
+  - `ConfigurationPrecedenceTests.CliOverridesConfigAndTemplate` — created in T015
+- `dotnet test -c Release` → 129/129 passed; all four acceptance tests green.
+- No new test files were needed.
+
+## Outcome
+No new files created. All 4 M2 acceptance tests confirmed present and passing.
+
+Tests passing:
+- `Typewriter.UnitTests/Cli/CliContractTests.cs` (T016)
+- `Typewriter.UnitTests/Diagnostics/DiagnosticFormatTests.cs` (T014)
+- `Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs` (T015)
+
+## Follow-ups
+- T018: Full restore/build/test run to confirm all 129 tests pass end-to-end.


### PR DESCRIPTION
## Summary

- Marks M2 as Done and sets M3 as the active milestone in `.ai/progress.md`
- Adds detail file links for T016 and T017 in the Active Tasks table
- Creates `.ai/tasks/T016-application-runner-stub.md` — captures the `ApplicationRunner` validation stub implementation journey
- Creates `.ai/tasks/T017-m2-acceptance-tests.md` — captures the M2 acceptance test verification
- Adds two new Decisions: D-0006 (`System.CommandLine` version pin) and D-0007 (`typewriter.json` `.git` boundary rule)
- Adds two new Patterns: `ApplicationRunner` stub pattern and `IDiagnosticReporter` injection pattern

## Test plan

- [ ] `.ai/progress.md` shows M2 as Done, M3 as active milestone
- [ ] All M2 task rows (T013–T018) present with status Done and detail file links
- [ ] D-0006 and D-0007 present in Decisions table
- [ ] New patterns present in Patterns & Conventions section
- [ ] No milestone scope or acceptance criteria duplicated from `DETAILED_IMPLEMENTATION_PLAN.md`

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)