### PR TITLE
feat: add bridge DTOs ProjectLoadPlan and LoadTarget (T021)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -55,6 +55,7 @@
 | T017 Add M2 acceptance tests (#64) | M2 | Executor | Done | [T017-m2-acceptance-tests.md](.ai/tasks/T017-m2-acceptance-tests.md) — Verified 4 acceptance tests already in place from T013-T016: `CliContractTests` (2), `DiagnosticFormatTests.MsBuildStyleMessage_IsParseable` (1), `ConfigurationPrecedenceTests.CliOverridesConfigAndTemplate` (1); build 0 errors/warnings, 129 tests pass |
 | T018 Run M2 acceptance criteria (#65) | M2 | Executor | Done | [T018-run-m2-acceptance-criteria.md](.ai/tasks/T018-run-m2-acceptance-criteria.md) — restore/build/test all pass; 129/129 tests pass; origin/ unchanged; zero VS coupling in M2 .cs source files |
 | T020 Add NuGet package refs to Loading.MSBuild (#76) | M3 | Executor | Done | `Microsoft.Build` 17.14.28 + `Microsoft.Build.Locator` 1.11.2 with `ExcludeAssets="runtime"` on Microsoft.Build; restore/build 0 errors, 129/129 tests pass |
+| T021 Create bridge DTOs ProjectLoadPlan.cs and LoadTarget.cs (#77) | M3 | Executor | Done | `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` + `LoadTarget.cs`; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Application/Orchestration/LoadTarget.cs
+++ b/src/Typewriter.Application/Orchestration/LoadTarget.cs
@@ -1,0 +1,10 @@
+namespace Typewriter.Application.Orchestration;
+
+public record LoadTarget(
+    string ProjectPath,
+    string ProjectName,
+    string TargetFramework,
+    string? Configuration,
+    string? RuntimeIdentifier,
+    int TraversalOrder
+);

--- a/src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs
+++ b/src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs
@@ -1,0 +1,8 @@
+namespace Typewriter.Application.Orchestration;
+
+public record ProjectLoadPlan(
+    string EntryPath,
+    string? SolutionDirectory,
+    IReadOnlyList<LoadTarget> Targets,
+    IReadOnlyDictionary<string, string> GlobalProperties
+);


### PR DESCRIPTION
## Summary

- Creates `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` — record DTO holding entry path, solution directory, load targets, and global properties
- Creates `src/Typewriter.Application/Orchestration/LoadTarget.cs` — record DTO holding per-project load context (path, name, TFM, configuration, RID, traversal order)
- Updates `.ai/progress.md` to mark T021 done

## Why

These bridge DTOs decouple `Typewriter.Loading.MSBuild` outputs from the higher-level orchestration layer, satisfying the M3 pipeline design described in `DETAILED_IMPLEMENTATION_PLAN.md`.

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] Both types in namespace `Typewriter.Application.Orchestration`
- [x] No VS dependencies introduced

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)