### PR TITLE
feat: add TW2002, TW2003, TW2401 diagnostic codes (T022)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -56,6 +56,7 @@
 | T018 Run M2 acceptance criteria (#65) | M2 | Executor | Done | [T018-run-m2-acceptance-criteria.md](.ai/tasks/T018-run-m2-acceptance-criteria.md) — restore/build/test all pass; 129/129 tests pass; origin/ unchanged; zero VS coupling in M2 .cs source files |
 | T020 Add NuGet package refs to Loading.MSBuild (#76) | M3 | Executor | Done | `Microsoft.Build` 17.14.28 + `Microsoft.Build.Locator` 1.11.2 with `ExcludeAssets="runtime"` on Microsoft.Build; restore/build 0 errors, 129/129 tests pass |
 | T021 Create bridge DTOs ProjectLoadPlan.cs and LoadTarget.cs (#77) | M3 | Executor | Done | `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` + `LoadTarget.cs`; build 0 errors/warnings |
+| T022 Expand DiagnosticCode.cs with TW2002, TW2003, TW2401 (#78) | M3 | Executor | Done | Added TW2002/TW2003 (Error) + TW2401 (Warning/Info) to `DiagnosticCode.cs`; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Application/Diagnostics/DiagnosticCode.cs
+++ b/src/Typewriter.Application/Diagnostics/DiagnosticCode.cs
@@ -11,6 +11,15 @@ public static class DiagnosticCode
     /// <summary>Restore failed.</summary>
     public const string TW2001 = "TW2001";
 
+    /// <summary>Project file not found at the specified path.</summary>
+    public const string TW2002 = "TW2002";
+
+    /// <summary>Restore assets missing (obj/project.assets.json not present); run with --restore.</summary>
+    public const string TW2003 = "TW2003";
+
+    /// <summary>Multi-target default selection: TFM was chosen implicitly because --framework was not specified.</summary>
+    public const string TW2401 = "TW2401";
+
     /// <summary>Template compile error.</summary>
     public const string TW3001 = "TW3001";
 


### PR DESCRIPTION
## Summary

- Added `TW2002` — Project file not found at the specified path (Error)
- Added `TW2003` — Restore assets missing (`obj/project.assets.json` not present); run with `--restore` (Error)
- Added `TW2401` — Multi-target default selection: TFM chosen implicitly (Warning/Info)

All three follow the existing `public const string TWxxxx = "TWxxxx"` pattern with XML `<summary>` docs in `DiagnosticCode.cs`. No existing codes were modified or removed.

Closes #78

## Test plan

- [x] `dotnet build -c Release` succeeds with 0 errors, 0 warnings
- [x] `TW2002`, `TW2003`, `TW2401` are accessible as `public const string` members of `DiagnosticCode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)