### PR TITLE
feat: add SimpleLib test fixture for M3 integration tests (T028)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -57,6 +57,7 @@
 | T020 Add NuGet package refs to Loading.MSBuild (#76) | M3 | Executor | Done | `Microsoft.Build` 17.14.28 + `Microsoft.Build.Locator` 1.11.2 with `ExcludeAssets="runtime"` on Microsoft.Build; restore/build 0 errors, 129/129 tests pass |
 | T021 Create bridge DTOs ProjectLoadPlan.cs and LoadTarget.cs (#77) | M3 | Executor | Done | `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` + `LoadTarget.cs`; build 0 errors/warnings |
 | T022 Expand DiagnosticCode.cs with TW2002, TW2003, TW2401 (#78) | M3 | Executor | Done | Added TW2002/TW2003 (Error) + TW2401 (Warning/Info) to `DiagnosticCode.cs`; build 0 errors/warnings |
+| T028 Create test fixture tests/fixtures/SimpleLib/SimpleLib.csproj (#79) | M3 | Executor | Done | `tests/fixtures/SimpleLib/SimpleLib.csproj` + `Class1.cs`; targets net10.0, no Typewriter refs |
 
 ## Decisions
 

--- a/tests/fixtures/SimpleLib/Class1.cs
+++ b/tests/fixtures/SimpleLib/Class1.cs
@@ -1,0 +1,3 @@
+namespace SimpleLib;
+
+public class Class1 { }

--- a/tests/fixtures/SimpleLib/SimpleLib.csproj
+++ b/tests/fixtures/SimpleLib/SimpleLib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Create `tests/fixtures/SimpleLib/SimpleLib.csproj` targeting `net10.0` with nullable and implicit usings enabled
- Create `tests/fixtures/SimpleLib/Class1.cs` minimal placeholder to make the project valid
- Fixture has no Typewriter project references — it is the *target* project loaded by integration tests
- Update `.ai/progress.md` to record T028 completion

## What changed

Two new files under `tests/fixtures/SimpleLib/`:
- `SimpleLib.csproj` — minimal SDK-style project for `net10.0`
- `Class1.cs` — empty placeholder class so the project compiles cleanly

## Why

M3 integration tests for `IProjectGraphService` need a standalone `.csproj` fixture to load. This provides that fixture without referencing any Typewriter projects, satisfying the acceptance criteria in #79.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)