### PR TITLE
feat: implement IInputResolver, InputResolver, and ResolvedInput (T023)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -58,6 +58,7 @@
 | T021 Create bridge DTOs ProjectLoadPlan.cs and LoadTarget.cs (#77) | M3 | Executor | Done | `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` + `LoadTarget.cs`; build 0 errors/warnings |
 | T022 Expand DiagnosticCode.cs with TW2002, TW2003, TW2401 (#78) | M3 | Executor | Done | Added TW2002/TW2003 (Error) + TW2401 (Warning/Info) to `DiagnosticCode.cs`; build 0 errors/warnings |
 | T028 Create test fixture tests/fixtures/SimpleLib/SimpleLib.csproj (#79) | M3 | Executor | Done | `tests/fixtures/SimpleLib/SimpleLib.csproj` + `Class1.cs`; targets net10.0, no Typewriter refs |
+| T023 Implement IInputResolver and ResolvedInput in Loading.MSBuild (#80) | M3 | Executor | Done | `ResolvedInput.cs`, `IInputResolver.cs`, `InputResolver.cs` in `src/Typewriter.Loading.MSBuild/`; inverted dep (Loading.MSBuild → Application); build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Application/Typewriter.Application.csproj
+++ b/src/Typewriter.Application/Typewriter.Application.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
     <ProjectReference Include="..\Typewriter.Generation\Typewriter.Generation.csproj" />
     <ProjectReference Include="..\Typewriter.CodeModel\Typewriter.CodeModel.csproj" />
     <ProjectReference Include="..\Typewriter.Metadata\Typewriter.Metadata.csproj" />

--- a/src/Typewriter.Loading.MSBuild/IInputResolver.cs
+++ b/src/Typewriter.Loading.MSBuild/IInputResolver.cs
@@ -1,0 +1,8 @@
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Loading.MSBuild;
+
+public interface IInputResolver
+{
+    Task<ResolvedInput?> ResolveAsync(string projectPath, IDiagnosticReporter reporter, CancellationToken ct = default);
+}

--- a/src/Typewriter.Loading.MSBuild/InputResolver.cs
+++ b/src/Typewriter.Loading.MSBuild/InputResolver.cs
@@ -1,0 +1,36 @@
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Loading.MSBuild;
+
+public sealed class InputResolver : IInputResolver
+{
+    public Task<ResolvedInput?> ResolveAsync(
+        string projectPath,
+        IDiagnosticReporter reporter,
+        CancellationToken ct = default)
+    {
+        // Expand ~ and environment variables, then resolve to an absolute path.
+        string expanded = projectPath;
+        if (expanded.StartsWith("~", StringComparison.Ordinal))
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            expanded = home + expanded.Substring(1);
+        }
+
+        expanded = Environment.ExpandEnvironmentVariables(expanded);
+        string resolvedPath = Path.GetFullPath(expanded);
+
+        if (!File.Exists(resolvedPath))
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                DiagnosticCode.TW2002,
+                $"Project file not found: '{resolvedPath}'",
+                File: resolvedPath));
+            return Task.FromResult<ResolvedInput?>(null);
+        }
+
+        string? solutionDirectory = Path.GetDirectoryName(resolvedPath);
+        return Task.FromResult<ResolvedInput?>(new ResolvedInput(resolvedPath, solutionDirectory));
+    }
+}

--- a/src/Typewriter.Loading.MSBuild/ResolvedInput.cs
+++ b/src/Typewriter.Loading.MSBuild/ResolvedInput.cs
@@ -1,0 +1,3 @@
+namespace Typewriter.Loading.MSBuild;
+
+public record ResolvedInput(string ProjectPath, string? SolutionDirectory);

--- a/src/Typewriter.Loading.MSBuild/Typewriter.Loading.MSBuild.csproj
+++ b/src/Typewriter.Loading.MSBuild/Typewriter.Loading.MSBuild.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <ProjectReference Include="..\Typewriter.Application\Typewriter.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!--
       ExcludeAssets="runtime" prevents MSBuild assemblies from being copied to the
       output directory. At runtime, Microsoft.Build.Locator dynamically loads them


### PR DESCRIPTION
## Summary

- Create `ResolvedInput` DTO record in `Typewriter.Loading.MSBuild`
- Create `IInputResolver` interface with `ResolveAsync(string, IDiagnosticReporter, CancellationToken)`
- Create `InputResolver` implementation that expands `~`/env-vars, resolves to absolute path, emits `TW2002` if file missing, and returns `ResolvedInput` on success
- Invert the project dependency: remove unused `Typewriter.Loading.MSBuild` ref from `Typewriter.Application.csproj` and add `Typewriter.Application` ref to `Typewriter.Loading.MSBuild.csproj` (avoids circular dependency, aligns with M3 layering where Loading.MSBuild uses Application's diagnostic contracts)

## Test plan

- [x] `dotnet build -c Release` succeeds with 0 errors, 0 warnings
- [ ] `IInputResolver.ResolveAsync` returns `null` and emits `TW2002` for missing file path
- [ ] `IInputResolver.ResolveAsync` returns valid `ResolvedInput` for existing `.csproj`

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)