### PR TITLE
feat: add IMsBuildLocatorService and MsBuildLocatorService in Typewriter.Loading.MSBuild (T025)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -59,6 +59,7 @@
 | T022 Expand DiagnosticCode.cs with TW2002, TW2003, TW2401 (#78) | M3 | Executor | Done | Added TW2002/TW2003 (Error) + TW2401 (Warning/Info) to `DiagnosticCode.cs`; build 0 errors/warnings |
 | T028 Create test fixture tests/fixtures/SimpleLib/SimpleLib.csproj (#79) | M3 | Executor | Done | `tests/fixtures/SimpleLib/SimpleLib.csproj` + `Class1.cs`; targets net10.0, no Typewriter refs |
 | T023 Implement IInputResolver and ResolvedInput in Loading.MSBuild (#80) | M3 | Executor | Done | `ResolvedInput.cs`, `IInputResolver.cs`, `InputResolver.cs` in `src/Typewriter.Loading.MSBuild/`; inverted dep (Loading.MSBuild → Application); build 0 errors/warnings |
+| T025 Implement MsBuildLocatorService in Loading.MSBuild (#81) | M3 | Executor | Done | `IMsBuildLocatorService.cs` + `MsBuildLocatorService.cs` in `src/Typewriter.Loading.MSBuild/`; Interlocked one-shot guard, TW2001 on failure; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Loading.MSBuild/IMsBuildLocatorService.cs
+++ b/src/Typewriter.Loading.MSBuild/IMsBuildLocatorService.cs
@@ -1,0 +1,8 @@
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Loading.MSBuild;
+
+public interface IMsBuildLocatorService
+{
+    void EnsureRegistered(IDiagnosticReporter reporter);
+}

--- a/src/Typewriter.Loading.MSBuild/MsBuildLocatorService.cs
+++ b/src/Typewriter.Loading.MSBuild/MsBuildLocatorService.cs
@@ -1,0 +1,28 @@
+using Microsoft.Build.Locator;
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Loading.MSBuild;
+
+public sealed class MsBuildLocatorService : IMsBuildLocatorService
+{
+    private static int _registered = 0;
+
+    public void EnsureRegistered(IDiagnosticReporter reporter)
+    {
+        if (Interlocked.CompareExchange(ref _registered, 1, 0) == 0)
+        {
+            try
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+            catch (Exception ex)
+            {
+                reporter.Report(new DiagnosticMessage(
+                    DiagnosticSeverity.Error,
+                    DiagnosticCode.TW2001,
+                    $"MSBuild SDK not found: {ex.Message}"));
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `IMsBuildLocatorService` interface with `EnsureRegistered(IDiagnosticReporter)` method
- Implements `MsBuildLocatorService` with a thread-safe one-shot `MSBuildLocator.RegisterDefaults()` guard using `Interlocked.CompareExchange`
- Emits `TW2001` diagnostic on registration failure and rethrows the exception

## What changed
- `src/Typewriter.Loading.MSBuild/IMsBuildLocatorService.cs` — new interface
- `src/Typewriter.Loading.MSBuild/MsBuildLocatorService.cs` — new sealed implementation

## Test plan
- [ ] `dotnet build -c Release` succeeds with 0 errors and 0 warnings ✅
- [ ] Calling `EnsureRegistered` twice does not throw (second call is a no-op)
- [ ] Single MSBuild registration per process — no `InvalidOperationException` from duplicate registration

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)