### PR TITLE
feat: add IRestoreService and RestoreService in Typewriter.Loading.MSBuild (T024)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T020)
+> Last touched: 2026-03-02 by Claude (Executor, T024)
 
 ## Current State
 
 - **Active milestone**: M3 - MSBuild project loading pipeline
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Continue M3 — implement project loader, restore checks, and TW2xxx diagnostics
+- **Next step**: Continue M3 — implement project loader and remaining M3 tasks
 
 ## Milestone Map
 
@@ -60,6 +60,7 @@
 | T028 Create test fixture tests/fixtures/SimpleLib/SimpleLib.csproj (#79) | M3 | Executor | Done | `tests/fixtures/SimpleLib/SimpleLib.csproj` + `Class1.cs`; targets net10.0, no Typewriter refs |
 | T023 Implement IInputResolver and ResolvedInput in Loading.MSBuild (#80) | M3 | Executor | Done | `ResolvedInput.cs`, `IInputResolver.cs`, `InputResolver.cs` in `src/Typewriter.Loading.MSBuild/`; inverted dep (Loading.MSBuild → Application); build 0 errors/warnings |
 | T025 Implement MsBuildLocatorService in Loading.MSBuild (#81) | M3 | Executor | Done | `IMsBuildLocatorService.cs` + `MsBuildLocatorService.cs` in `src/Typewriter.Loading.MSBuild/`; Interlocked one-shot guard, TW2001 on failure; build 0 errors/warnings |
+| T024 Implement IRestoreService and RestoreService in Loading.MSBuild (#82) | M3 | Executor | Done | `IRestoreService.cs` + `RestoreService.cs` in `src/Typewriter.Loading.MSBuild/`; CheckAssetsAsync checks obj/project.assets.json, RestoreAsync runs dotnet restore and emits TW2001 on failure; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Loading.MSBuild/IRestoreService.cs
+++ b/src/Typewriter.Loading.MSBuild/IRestoreService.cs
@@ -1,0 +1,9 @@
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Loading.MSBuild;
+
+public interface IRestoreService
+{
+    Task<bool> CheckAssetsAsync(string projectPath, CancellationToken ct = default);
+    Task<bool> RestoreAsync(string projectPath, IDiagnosticReporter reporter, CancellationToken ct = default);
+}

--- a/src/Typewriter.Loading.MSBuild/RestoreService.cs
+++ b/src/Typewriter.Loading.MSBuild/RestoreService.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Loading.MSBuild;
+
+public sealed class RestoreService : IRestoreService
+{
+    public Task<bool> CheckAssetsAsync(string projectPath, CancellationToken ct = default)
+    {
+        var dir = Path.GetDirectoryName(projectPath)!;
+        var assetsFile = Path.Combine(dir, "obj", "project.assets.json");
+        return Task.FromResult(File.Exists(assetsFile));
+    }
+
+    public async Task<bool> RestoreAsync(string projectPath, IDiagnosticReporter reporter, CancellationToken ct = default)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"restore \"{projectPath}\"")
+        {
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        var stderr = await process.StandardError.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+
+        if (process.ExitCode != 0)
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                DiagnosticCode.TW2001,
+                $"dotnet restore failed:{(string.IsNullOrWhiteSpace(stderr) ? string.Empty : $"\n{stderr.TrimEnd()}")}"));
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `IRestoreService` interface with `CheckAssetsAsync` and `RestoreAsync` methods
- Add `RestoreService` implementation that checks `obj/project.assets.json` and runs `dotnet restore` as a subprocess
- Emit `TW2001` diagnostic with captured stderr on non-zero restore exit code
- Use `Path.Combine` throughout — no hardcoded directory separators

## Test plan

- [x] `dotnet build -c Release` succeeds with 0 errors and 0 warnings
- [x] `CheckAssetsAsync` checks `Path.Combine(dir, "obj", "project.assets.json")` via `File.Exists`
- [x] `RestoreAsync` captures stderr and reports `TW2001` as `Error` on failure, returns `false`
- [x] On success `RestoreAsync` returns `true`

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)