### PR TITLE
feat: add IProjectGraphService and ProjectGraphService in Typewriter.Loading.MSBuild (T026)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M3 - MSBuild project loading pipeline
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Continue M3 — implement project loader and remaining M3 tasks
+- **Next step**: Continue M3 — implement remaining M3 tasks (T027 SolutionGraphService, etc.)
 
 ## Milestone Map
 
@@ -61,6 +61,7 @@
 | T023 Implement IInputResolver and ResolvedInput in Loading.MSBuild (#80) | M3 | Executor | Done | `ResolvedInput.cs`, `IInputResolver.cs`, `InputResolver.cs` in `src/Typewriter.Loading.MSBuild/`; inverted dep (Loading.MSBuild → Application); build 0 errors/warnings |
 | T025 Implement MsBuildLocatorService in Loading.MSBuild (#81) | M3 | Executor | Done | `IMsBuildLocatorService.cs` + `MsBuildLocatorService.cs` in `src/Typewriter.Loading.MSBuild/`; Interlocked one-shot guard, TW2001 on failure; build 0 errors/warnings |
 | T024 Implement IRestoreService and RestoreService in Loading.MSBuild (#82) | M3 | Executor | Done | `IRestoreService.cs` + `RestoreService.cs` in `src/Typewriter.Loading.MSBuild/`; CheckAssetsAsync checks obj/project.assets.json, RestoreAsync runs dotnet restore and emits TW2001 on failure; build 0 errors/warnings |
+| T026 Implement IProjectGraphService and ProjectGraphService in Loading.MSBuild (#83) | M3 | Executor | Done | `IProjectGraphService.cs` + `ProjectGraphService.cs` in `src/Typewriter.Loading.MSBuild/`; Kahn's topological sort with path tie-breaker, multi-target selection (TW2401), TFM filtering (TW2002), assets check (TW2003); build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Loading.MSBuild/IProjectGraphService.cs
+++ b/src/Typewriter.Loading.MSBuild/IProjectGraphService.cs
@@ -1,0 +1,15 @@
+using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Orchestration;
+
+namespace Typewriter.Loading.MSBuild;
+
+public interface IProjectGraphService
+{
+    Task<ProjectLoadPlan?> BuildPlanAsync(
+        ResolvedInput input,
+        string? framework,
+        string? configuration,
+        string? runtime,
+        IDiagnosticReporter reporter,
+        CancellationToken ct = default);
+}

--- a/src/Typewriter.Loading.MSBuild/ProjectGraphService.cs
+++ b/src/Typewriter.Loading.MSBuild/ProjectGraphService.cs
@@ -1,0 +1,162 @@
+using Microsoft.Build.Graph;
+using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Orchestration;
+
+namespace Typewriter.Loading.MSBuild;
+
+public sealed class ProjectGraphService : IProjectGraphService
+{
+    private readonly IMsBuildLocatorService _locatorService;
+
+    public ProjectGraphService(IMsBuildLocatorService locatorService)
+    {
+        _locatorService = locatorService;
+    }
+
+    public Task<ProjectLoadPlan?> BuildPlanAsync(
+        ResolvedInput input,
+        string? framework,
+        string? configuration,
+        string? runtime,
+        IDiagnosticReporter reporter,
+        CancellationToken ct = default)
+    {
+        _locatorService.EnsureRegistered(reporter);
+
+        if (reporter.ErrorCount > 0)
+            return Task.FromResult<ProjectLoadPlan?>(null);
+
+        var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Configuration"] = configuration ?? "Release"
+        };
+        if (runtime != null)
+            globalProperties["RuntimeIdentifier"] = runtime;
+
+        ProjectGraph graph;
+        try
+        {
+            graph = new ProjectGraph(input.ProjectPath, globalProperties);
+        }
+        catch (Exception ex)
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                DiagnosticCode.TW2002,
+                $"Failed to load project graph from '{input.ProjectPath}': {ex.Message}"));
+            return Task.FromResult<ProjectLoadPlan?>(null);
+        }
+
+        var sortedNodes = TopologicalSort(graph);
+        var targets = new List<LoadTarget>(sortedNodes.Count);
+        var hasError = false;
+
+        for (int i = 0; i < sortedNodes.Count; i++)
+        {
+            var node = sortedNodes[i];
+            var projectPath = node.ProjectInstance.FullPath;
+            var projectName = Path.GetFileNameWithoutExtension(projectPath);
+            var tfms = GetTargetFrameworks(node);
+
+            string selectedTfm;
+            if (framework != null)
+            {
+                if (!tfms.Contains(framework, StringComparer.OrdinalIgnoreCase))
+                {
+                    reporter.Report(new DiagnosticMessage(
+                        DiagnosticSeverity.Error,
+                        DiagnosticCode.TW2002,
+                        $"Project '{projectPath}' does not target framework '{framework}'."));
+                    hasError = true;
+                    continue;
+                }
+                selectedTfm = framework;
+            }
+            else
+            {
+                selectedTfm = tfms.Count > 0 ? tfms[0] : string.Empty;
+                if (tfms.Count > 1)
+                {
+                    reporter.Report(new DiagnosticMessage(
+                        DiagnosticSeverity.Info,
+                        DiagnosticCode.TW2401,
+                        $"Project '{projectPath}' targets multiple frameworks ({string.Join(", ", tfms)}); defaulting to '{selectedTfm}'. Use --framework to specify."));
+                }
+            }
+
+            var dir = Path.GetDirectoryName(projectPath)!;
+            var assetsFile = Path.Combine(dir, "obj", "project.assets.json");
+            if (!File.Exists(assetsFile))
+            {
+                reporter.Report(new DiagnosticMessage(
+                    DiagnosticSeverity.Error,
+                    DiagnosticCode.TW2003,
+                    $"Restore assets missing for '{projectPath}'. Run with --restore or run 'dotnet restore' manually."));
+                hasError = true;
+            }
+
+            targets.Add(new LoadTarget(projectPath, projectName, selectedTfm, configuration, runtime, i));
+        }
+
+        if (hasError)
+            return Task.FromResult<ProjectLoadPlan?>(null);
+
+        var plan = new ProjectLoadPlan(input.ProjectPath, input.SolutionDirectory, targets, globalProperties);
+        return Task.FromResult<ProjectLoadPlan?>(plan);
+    }
+
+    private static List<string> GetTargetFrameworks(ProjectGraphNode node)
+    {
+        var tfms = node.ProjectInstance.GetPropertyValue("TargetFrameworks");
+        if (!string.IsNullOrWhiteSpace(tfms))
+        {
+            return tfms.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                       .ToList();
+        }
+
+        var tfm = node.ProjectInstance.GetPropertyValue("TargetFramework");
+        if (!string.IsNullOrWhiteSpace(tfm))
+            return [tfm];
+
+        return [];
+    }
+
+    private static List<ProjectGraphNode> TopologicalSort(ProjectGraph graph)
+    {
+        // Kahn's algorithm: dependencies-first ordering.
+        // In-degree = number of direct ProjectReferences (edges to dependencies).
+        // Nodes with in-degree 0 have no unprocessed dependencies — start there.
+        // Tie-breaker: sort by FullPath ascending for determinism.
+        var inDegree = graph.ProjectNodes
+            .ToDictionary(n => n, n => n.ProjectReferences.Count);
+
+        var available = new SortedSet<ProjectGraphNode>(
+            Comparer<ProjectGraphNode>.Create((a, b) =>
+                StringComparer.Ordinal.Compare(a.ProjectInstance.FullPath, b.ProjectInstance.FullPath)));
+
+        foreach (var (node, deg) in inDegree)
+        {
+            if (deg == 0)
+                available.Add(node);
+        }
+
+        var result = new List<ProjectGraphNode>(graph.ProjectNodes.Count);
+
+        while (available.Count > 0)
+        {
+            var node = available.Min!;
+            available.Remove(node);
+            result.Add(node);
+
+            foreach (var dependant in node.ReferencingProjects
+                         .OrderBy(n => n.ProjectInstance.FullPath, StringComparer.Ordinal))
+            {
+                inDegree[dependant]--;
+                if (inDegree[dependant] == 0)
+                    available.Add(dependant);
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IProjectGraphService` interface with `BuildPlanAsync` method
- Implements `ProjectGraphService` with full `ProjectGraph`-based loading pipeline:
  - Calls `IMsBuildLocatorService.EnsureRegistered` before any MSBuild graph construction
  - Builds `GlobalProperties` from `configuration`/`runtime`; defaults `Configuration` to `"Release"`
  - Constructs `ProjectGraph` and performs deterministic topological sort (Kahn's algorithm, stable path tie-breaker)
  - Multi-target: emits `TW2002` error if specified `--framework` not found; emits `TW2401` info when selecting first TFM implicitly
  - Checks `obj/project.assets.json` for each project path; emits `TW2003` if missing
  - Returns `ProjectLoadPlan` with `EntryPath`, `SolutionDirectory`, `Targets`, and `GlobalProperties`

Closes #83

## Test plan

- [x] `dotnet build -c Release` succeeds with 0 errors and 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)