### PR TITLE
feat: wire ApplicationRunner to MSBuild loading pipeline (T027)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T024)
+> Last touched: 2026-03-02 by Claude (Executor, T027)
 
 ## Current State
 
 - **Active milestone**: M3 - MSBuild project loading pipeline
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Continue M3 — implement remaining M3 tasks (T027 SolutionGraphService, etc.)
+- **Next step**: Continue M3 — remaining tasks (SolutionGraphService for .sln/.slnx, M3 acceptance tests)
 
 ## Milestone Map
 
@@ -62,6 +62,7 @@
 | T025 Implement MsBuildLocatorService in Loading.MSBuild (#81) | M3 | Executor | Done | `IMsBuildLocatorService.cs` + `MsBuildLocatorService.cs` in `src/Typewriter.Loading.MSBuild/`; Interlocked one-shot guard, TW2001 on failure; build 0 errors/warnings |
 | T024 Implement IRestoreService and RestoreService in Loading.MSBuild (#82) | M3 | Executor | Done | `IRestoreService.cs` + `RestoreService.cs` in `src/Typewriter.Loading.MSBuild/`; CheckAssetsAsync checks obj/project.assets.json, RestoreAsync runs dotnet restore and emits TW2001 on failure; build 0 errors/warnings |
 | T026 Implement IProjectGraphService and ProjectGraphService in Loading.MSBuild (#83) | M3 | Executor | Done | `IProjectGraphService.cs` + `ProjectGraphService.cs` in `src/Typewriter.Loading.MSBuild/`; Kahn's topological sort with path tie-breaker, multi-target selection (TW2401), TFM filtering (TW2002), assets check (TW2003); build 0 errors/warnings |
+| T027 Wire ApplicationRunner to MSBuild loading services (#84) | M3 | Executor | Done | [T027-wire-applicationrunner-to-msbuild.md](.ai/tasks/T027-wire-applicationrunner-to-msbuild.md) — Moved service interfaces to `Typewriter.Application.Loading`; `ApplicationRunner` full pipeline: resolve→restore→graph; `Program.cs` composes concrete services; build 0 errors/warnings, 129/129 tests pass |
 
 ## Decisions
 

--- a/.ai/tasks/T027-wire-applicationrunner-to-msbuild.md
+++ b/.ai/tasks/T027-wire-applicationrunner-to-msbuild.md
@@ -1,0 +1,57 @@
+# T027: Wire ApplicationRunner to MSBuild Loading Services
+- Milestone: M3
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Replace the validation-only stub in `ApplicationRunner.RunAsync()` with real calls to the MSBuild loading pipeline: `IInputResolver` → `IRestoreService` → `IProjectGraphService`. Map loader errors to exit code 3.
+
+## Approach
+
+To wire the loading pipeline into `ApplicationRunner` without creating a circular dependency (since `Typewriter.Loading.MSBuild` already references `Typewriter.Application`), the service interfaces were moved to `Typewriter.Application.Loading`:
+
+- `IInputResolver`, `IRestoreService`, `IProjectGraphService`, `IMsBuildLocatorService`, `ResolvedInput` moved from `Typewriter.Loading.MSBuild` → `Typewriter.Application/Loading/` (namespace `Typewriter.Application.Loading`)
+- Implementations in `Typewriter.Loading.MSBuild` updated to `using Typewriter.Application.Loading;`
+- `ApplicationRunner` now accepts interfaces via constructor injection
+- `Typewriter.Cli/Program.cs` creates the concrete implementations and injects them
+- `Typewriter.Cli.csproj` gains a reference to `Typewriter.Loading.MSBuild`
+
+## Journey
+### 2026-03-02
+- Read AGENTS.md and progress.md to orient
+- Identified circular dependency: `Loading.MSBuild → Application`, so `Application` cannot reference `Loading.MSBuild` directly
+- Solution: move the service interfaces (abstractions) to `Typewriter.Application.Loading` — Dependency Inversion Principle
+- Created 5 new files in `src/Typewriter.Application/Loading/`: `ResolvedInput.cs`, `IInputResolver.cs`, `IRestoreService.cs`, `IProjectGraphService.cs`, `IMsBuildLocatorService.cs`
+- Deleted old interface/DTO files from `Typewriter.Loading.MSBuild/` (5 files removed)
+- Updated implementations: added `using Typewriter.Application.Loading;` to `InputResolver.cs`, `RestoreService.cs`, `ProjectGraphService.cs`, `MsBuildLocatorService.cs`
+- Rewrote `ApplicationRunner.cs` with constructor injection and full pipeline: resolve → check assets → restore if needed → build graph
+- Updated `Program.cs` to create concrete services and inject into `ApplicationRunner`
+- Added `Typewriter.Loading.MSBuild` project reference to `Typewriter.Cli.csproj`
+- Updated `CliContractTests.cs` to use stub implementations (tests bypass file system)
+- Build: 0 errors, 0 warnings; 129/129 tests pass
+
+## Outcome
+Files changed:
+- **NEW**: `src/Typewriter.Application/Loading/ResolvedInput.cs`
+- **NEW**: `src/Typewriter.Application/Loading/IInputResolver.cs`
+- **NEW**: `src/Typewriter.Application/Loading/IRestoreService.cs`
+- **NEW**: `src/Typewriter.Application/Loading/IProjectGraphService.cs`
+- **NEW**: `src/Typewriter.Application/Loading/IMsBuildLocatorService.cs`
+- **DELETED**: `src/Typewriter.Loading.MSBuild/ResolvedInput.cs`
+- **DELETED**: `src/Typewriter.Loading.MSBuild/IInputResolver.cs`
+- **DELETED**: `src/Typewriter.Loading.MSBuild/IRestoreService.cs`
+- **DELETED**: `src/Typewriter.Loading.MSBuild/IProjectGraphService.cs`
+- **DELETED**: `src/Typewriter.Loading.MSBuild/IMsBuildLocatorService.cs`
+- **MODIFIED**: `src/Typewriter.Loading.MSBuild/InputResolver.cs` (added `using Typewriter.Application.Loading;`)
+- **MODIFIED**: `src/Typewriter.Loading.MSBuild/RestoreService.cs` (added `using Typewriter.Application.Loading;`)
+- **MODIFIED**: `src/Typewriter.Loading.MSBuild/ProjectGraphService.cs` (added `using Typewriter.Application.Loading;`)
+- **MODIFIED**: `src/Typewriter.Loading.MSBuild/MsBuildLocatorService.cs` (added `using Typewriter.Application.Loading;`)
+- **MODIFIED**: `src/Typewriter.Application/ApplicationRunner.cs` (full pipeline, constructor injection)
+- **MODIFIED**: `src/Typewriter.Cli/Program.cs` (compose services, inject into runner)
+- **MODIFIED**: `src/Typewriter.Cli/Typewriter.Cli.csproj` (added Loading.MSBuild reference)
+- **MODIFIED**: `tests/Typewriter.UnitTests/Cli/CliContractTests.cs` (stub services for isolation)
+
+## Follow-ups
+- T029+ (remaining M3 tasks): integrate `ProjectLoadPlan` into the metadata extraction stage (M5)

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -1,41 +1,95 @@
 using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
 
 namespace Typewriter.Application;
 
 /// <summary>
-/// Orchestrates the generate pipeline. M2 stub — validates inputs only; generation logic added in M3+.
+/// Orchestrates the generate pipeline: input resolution → restore → project graph → generation.
 /// </summary>
 public sealed class ApplicationRunner
 {
+    private readonly IInputResolver _inputResolver;
+    private readonly IRestoreService _restoreService;
+    private readonly IProjectGraphService _projectGraphService;
+
+    public ApplicationRunner(
+        IInputResolver inputResolver,
+        IRestoreService restoreService,
+        IProjectGraphService projectGraphService)
+    {
+        _inputResolver = inputResolver;
+        _restoreService = restoreService;
+        _projectGraphService = projectGraphService;
+    }
+
     /// <summary>
-    /// Validates inputs and returns an exit code.
+    /// Validates inputs and runs the loading pipeline. Returns an exit code.
     /// </summary>
     /// <returns>
     /// 0 — success;
     /// 1 — warnings elevated to errors (<see cref="GenerateCommandOptions.FailOnWarnings"/> is true and warnings exist);
-    /// 2 — argument/input errors (empty templates, missing solution/project);
-    /// 3 — SDK/restore/load/build errors (reserved; not triggered in M2 stub).
+    /// 2 — argument/input errors (empty templates, missing solution/project, file not found);
+    /// 3 — SDK/restore/load/build errors.
     /// </returns>
-    public Task<int> RunAsync(
+    public async Task<int> RunAsync(
         GenerateCommandOptions options,
         IDiagnosticReporter reporter,
         CancellationToken cancellationToken = default)
     {
+        // 1. Validate templates argument.
         if (options.Templates == null || options.Templates.Count == 0)
-            return Task.FromResult(2);
+            return 2;
 
+        // 2. Validate solution/project argument.
         if (string.IsNullOrWhiteSpace(options.Solution) && string.IsNullOrWhiteSpace(options.Project))
         {
             reporter.Report(new DiagnosticMessage(
                 DiagnosticSeverity.Error,
                 DiagnosticCode.TW1002,
                 "Either --solution or --project must be provided."));
-            return Task.FromResult(2);
+            return 2;
         }
 
-        if (options.FailOnWarnings && reporter.WarningCount > 0)
-            return Task.FromResult(1);
+        // 3. Resolve the input path to an absolute, validated file path.
+        var projectArg = string.IsNullOrWhiteSpace(options.Project) ? options.Solution! : options.Project;
+        var resolvedInput = await _inputResolver.ResolveAsync(projectArg, reporter, cancellationToken);
+        if (resolvedInput is null)
+            return 2;
 
-        return Task.FromResult(0);
+        // 4. Check restore assets; run restore if requested.
+        var assetsPresent = await _restoreService.CheckAssetsAsync(resolvedInput.ProjectPath, cancellationToken);
+        if (!assetsPresent)
+        {
+            if (!options.Restore)
+            {
+                reporter.Report(new DiagnosticMessage(
+                    DiagnosticSeverity.Error,
+                    DiagnosticCode.TW2003,
+                    $"Restore assets missing for '{resolvedInput.ProjectPath}'. Run with --restore or run 'dotnet restore' manually."));
+                return 3;
+            }
+
+            var restoreOk = await _restoreService.RestoreAsync(resolvedInput.ProjectPath, reporter, cancellationToken);
+            if (!restoreOk)
+                return 3;
+        }
+
+        // 5. Build the project graph / load plan.
+        var plan = await _projectGraphService.BuildPlanAsync(
+            resolvedInput,
+            options.Framework,
+            options.Configuration,
+            options.Runtime,
+            reporter,
+            cancellationToken);
+
+        if (plan is null)
+            return 3;
+
+        // 6. Elevate warnings to errors if --fail-on-warnings was specified.
+        if (options.FailOnWarnings && reporter.WarningCount > 0)
+            return 1;
+
+        return 0;
     }
 }

--- a/src/Typewriter.Application/Loading/IInputResolver.cs
+++ b/src/Typewriter.Application/Loading/IInputResolver.cs
@@ -1,6 +1,6 @@
 using Typewriter.Application.Diagnostics;
 
-namespace Typewriter.Loading.MSBuild;
+namespace Typewriter.Application.Loading;
 
 public interface IInputResolver
 {

--- a/src/Typewriter.Application/Loading/IMsBuildLocatorService.cs
+++ b/src/Typewriter.Application/Loading/IMsBuildLocatorService.cs
@@ -1,6 +1,6 @@
 using Typewriter.Application.Diagnostics;
 
-namespace Typewriter.Loading.MSBuild;
+namespace Typewriter.Application.Loading;
 
 public interface IMsBuildLocatorService
 {

--- a/src/Typewriter.Application/Loading/IProjectGraphService.cs
+++ b/src/Typewriter.Application/Loading/IProjectGraphService.cs
@@ -1,7 +1,7 @@
 using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Orchestration;
 
-namespace Typewriter.Loading.MSBuild;
+namespace Typewriter.Application.Loading;
 
 public interface IProjectGraphService
 {

--- a/src/Typewriter.Application/Loading/IRestoreService.cs
+++ b/src/Typewriter.Application/Loading/IRestoreService.cs
@@ -1,6 +1,6 @@
 using Typewriter.Application.Diagnostics;
 
-namespace Typewriter.Loading.MSBuild;
+namespace Typewriter.Application.Loading;
 
 public interface IRestoreService
 {

--- a/src/Typewriter.Application/Loading/ResolvedInput.cs
+++ b/src/Typewriter.Application/Loading/ResolvedInput.cs
@@ -1,3 +1,3 @@
-namespace Typewriter.Loading.MSBuild;
+namespace Typewriter.Application.Loading;
 
 public record ResolvedInput(string ProjectPath, string? SolutionDirectory);

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -4,6 +4,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
+using Typewriter.Loading.MSBuild;
 
 var rootCommand = new RootCommand("typewriter-cli \u2014 standalone Typewriter code generator");
 
@@ -53,7 +54,14 @@ generateCommand.SetHandler(async (InvocationContext ctx) =>
         failOnWarnings: pr.GetValueForOption(failOnWarningsOpt));
 
     var reporter = new MsBuildDiagnosticReporter();
-    var runner = new ApplicationRunner();
+
+    // Compose the loading pipeline services.
+    var locatorService = new MsBuildLocatorService();
+    var inputResolver = new InputResolver();
+    var restoreService = new RestoreService();
+    var projectGraphService = new ProjectGraphService(locatorService);
+
+    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService);
     ctx.ExitCode = await runner.RunAsync(options, reporter, ctx.GetCancellationToken());
 });
 

--- a/src/Typewriter.Cli/Typewriter.Cli.csproj
+++ b/src/Typewriter.Cli/Typewriter.Cli.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Typewriter.Application\Typewriter.Application.csproj" />
+    <ProjectReference Include="..\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Typewriter.Loading.MSBuild/InputResolver.cs
+++ b/src/Typewriter.Loading.MSBuild/InputResolver.cs
@@ -1,4 +1,5 @@
 using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
 
 namespace Typewriter.Loading.MSBuild;
 

--- a/src/Typewriter.Loading.MSBuild/MsBuildLocatorService.cs
+++ b/src/Typewriter.Loading.MSBuild/MsBuildLocatorService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Build.Locator;
 using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
 
 namespace Typewriter.Loading.MSBuild;
 

--- a/src/Typewriter.Loading.MSBuild/ProjectGraphService.cs
+++ b/src/Typewriter.Loading.MSBuild/ProjectGraphService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Build.Graph;
 using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
 using Typewriter.Application.Orchestration;
 
 namespace Typewriter.Loading.MSBuild;

--- a/src/Typewriter.Loading.MSBuild/RestoreService.cs
+++ b/src/Typewriter.Loading.MSBuild/RestoreService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
 
 namespace Typewriter.Loading.MSBuild;
 

--- a/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
+++ b/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
@@ -1,5 +1,7 @@
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
+using Typewriter.Application.Orchestration;
 using Xunit;
 
 namespace Typewriter.UnitTests.Cli;
@@ -27,10 +29,46 @@ public class CliContractTests
         public int ErrorCount => _errorCount;
     }
 
+    /// <summary>Input resolver stub that always returns a successful resolved input.</summary>
+    private sealed class StubInputResolver : IInputResolver
+    {
+        public Task<ResolvedInput?> ResolveAsync(string projectPath, IDiagnosticReporter reporter, CancellationToken ct = default)
+            => Task.FromResult<ResolvedInput?>(new ResolvedInput(projectPath, null));
+    }
+
+    /// <summary>Restore service stub that reports assets as present.</summary>
+    private sealed class StubRestoreService : IRestoreService
+    {
+        public Task<bool> CheckAssetsAsync(string projectPath, CancellationToken ct = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RestoreAsync(string projectPath, IDiagnosticReporter reporter, CancellationToken ct = default)
+            => Task.FromResult(true);
+    }
+
+    /// <summary>Project graph service stub that returns an empty but non-null load plan.</summary>
+    private sealed class StubProjectGraphService : IProjectGraphService
+    {
+        public Task<ProjectLoadPlan?> BuildPlanAsync(
+            ResolvedInput input,
+            string? framework,
+            string? configuration,
+            string? runtime,
+            IDiagnosticReporter reporter,
+            CancellationToken ct = default)
+        {
+            var plan = new ProjectLoadPlan(input.ProjectPath, input.SolutionDirectory, [], new Dictionary<string, string>());
+            return Task.FromResult<ProjectLoadPlan?>(plan);
+        }
+    }
+
+    private static ApplicationRunner CreateRunner()
+        => new ApplicationRunner(new StubInputResolver(), new StubRestoreService(), new StubProjectGraphService());
+
     [Fact]
     public async Task Generate_InvalidArgs_Returns2()
     {
-        var runner = new ApplicationRunner();
+        var runner = CreateRunner();
         var reporter = new FakeDiagnosticReporter();
 
         // Empty templates + no solution/project → exit code 2
@@ -55,7 +93,7 @@ public class CliContractTests
     [Fact]
     public async Task Generate_WarningsWithFailFlag_Returns1()
     {
-        var runner = new ApplicationRunner();
+        var runner = CreateRunner();
         // Pre-seed the reporter with 1 warning to simulate a prior warning being reported.
         var reporter = new FakeDiagnosticReporter(warningCount: 1);
 


### PR DESCRIPTION
## Summary

- Moved service interfaces (`IInputResolver`, `IRestoreService`, `IProjectGraphService`, `IMsBuildLocatorService`, `ResolvedInput`) from `Typewriter.Loading.MSBuild` → `Typewriter.Application.Loading` to apply Dependency Inversion and avoid a circular reference
- `ApplicationRunner.RunAsync` now runs the full M3 loading pipeline: resolve → restore check → graph build, with correct exit-code mapping (2 for missing input, 3 for loader failures)
- `Program.cs` composes the concrete MSBuild service implementations and injects them into `ApplicationRunner`
- `Typewriter.Cli.csproj` gains a `ProjectReference` to `Typewriter.Loading.MSBuild`
- `CliContractTests` updated with stub implementations to keep tests isolated from the filesystem

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] `dotnet test -c Release` — 129/129 tests pass
- [x] Exit codes 0/1/2/3 preserved per CLI contract
- [x] `--restore`, `--framework`, `--configuration`, `--runtime` options passed through to the loading pipeline

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)