### PR TITLE
feat: add M3 ProjectLoader unit tests (T029)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M3 - MSBuild project loading pipeline
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Continue M3 — remaining tasks (SolutionGraphService for .sln/.slnx, M3 acceptance tests)
+- **Next step**: Continue M3 — remaining tasks (SolutionGraphService for .sln/.slnx, verify M3 acceptance criteria)
 
 ## Milestone Map
 
@@ -63,6 +63,7 @@
 | T024 Implement IRestoreService and RestoreService in Loading.MSBuild (#82) | M3 | Executor | Done | `IRestoreService.cs` + `RestoreService.cs` in `src/Typewriter.Loading.MSBuild/`; CheckAssetsAsync checks obj/project.assets.json, RestoreAsync runs dotnet restore and emits TW2001 on failure; build 0 errors/warnings |
 | T026 Implement IProjectGraphService and ProjectGraphService in Loading.MSBuild (#83) | M3 | Executor | Done | `IProjectGraphService.cs` + `ProjectGraphService.cs` in `src/Typewriter.Loading.MSBuild/`; Kahn's topological sort with path tie-breaker, multi-target selection (TW2401), TFM filtering (TW2002), assets check (TW2003); build 0 errors/warnings |
 | T027 Wire ApplicationRunner to MSBuild loading services (#84) | M3 | Executor | Done | [T027-wire-applicationrunner-to-msbuild.md](.ai/tasks/T027-wire-applicationrunner-to-msbuild.md) — Moved service interfaces to `Typewriter.Application.Loading`; `ApplicationRunner` full pipeline: resolve→restore→graph; `Program.cs` composes concrete services; build 0 errors/warnings, 129/129 tests pass |
+| T029 Add M3 unit tests for ProjectLoader (#85) | M3 | Executor | Done | `tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs` — 3 NSubstitute tests: assets-exist (no restore), missing-assets without restore (TW2003), restore path; NSubstitute 5.x added to test project; all 3 tests pass |
 
 ## Decisions
 

--- a/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
+++ b/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
@@ -1,0 +1,143 @@
+using NSubstitute;
+using Typewriter.Application;
+using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
+using Typewriter.Application.Orchestration;
+using Xunit;
+
+namespace Typewriter.UnitTests.Loading;
+
+public class ProjectLoaderTests
+{
+    private const string ProjectPath = "SimpleLib/SimpleLib.csproj";
+
+    private static ProjectLoadPlan ValidPlan(string projectPath) =>
+        new ProjectLoadPlan(
+            projectPath,
+            null,
+            [new LoadTarget(projectPath, "SimpleLib", "net10.0", null, null, 0)],
+            new Dictionary<string, string>());
+
+    private static GenerateCommandOptions MakeOptions(bool restore, string project = ProjectPath) =>
+        GenerateCommandOptions.Merge(
+            config: null,
+            templates: ["tmpl.tst"],
+            solution: null,
+            project: project,
+            framework: null,
+            configuration: null,
+            runtime: null,
+            restore: restore,
+            output: null,
+            verbosity: null,
+            failOnWarnings: false);
+
+    [Fact]
+    public async Task Csproj_LoadsWithoutRestore_WhenAssetsExist()
+    {
+        // Arrange
+        var inputResolver = Substitute.For<IInputResolver>();
+        var restoreService = Substitute.For<IRestoreService>();
+        var graphService = Substitute.For<IProjectGraphService>();
+        var reporter = Substitute.For<IDiagnosticReporter>();
+
+        inputResolver
+            .ResolveAsync(Arg.Any<string>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ResolvedInput?>(new ResolvedInput(ProjectPath, null)));
+
+        restoreService
+            .CheckAssetsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+
+        graphService
+            .BuildPlanAsync(
+                Arg.Any<ResolvedInput>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<IDiagnosticReporter>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ProjectLoadPlan?>(ValidPlan(ProjectPath)));
+
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService);
+
+        // Act
+        var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        await restoreService
+            .DidNotReceive()
+            .RestoreAsync(Arg.Any<string>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Csproj_MissingAssetsWithoutRestore_ReturnsTW2003()
+    {
+        // Arrange
+        var inputResolver = Substitute.For<IInputResolver>();
+        var restoreService = Substitute.For<IRestoreService>();
+        var graphService = Substitute.For<IProjectGraphService>();
+        var reporter = Substitute.For<IDiagnosticReporter>();
+
+        inputResolver
+            .ResolveAsync(Arg.Any<string>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ResolvedInput?>(new ResolvedInput(ProjectPath, null)));
+
+        restoreService
+            .CheckAssetsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(false));
+
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService);
+
+        // Act
+        var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
+
+        // Assert
+        Assert.Equal(3, exitCode);
+        reporter.Received().Report(Arg.Is<DiagnosticMessage>(m => m.Code == DiagnosticCode.TW2003));
+    }
+
+    [Fact]
+    public async Task Csproj_WithRestore_LoadsAfterRestore()
+    {
+        // Arrange
+        var inputResolver = Substitute.For<IInputResolver>();
+        var restoreService = Substitute.For<IRestoreService>();
+        var graphService = Substitute.For<IProjectGraphService>();
+        var reporter = Substitute.For<IDiagnosticReporter>();
+
+        inputResolver
+            .ResolveAsync(Arg.Any<string>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ResolvedInput?>(new ResolvedInput(ProjectPath, null)));
+
+        restoreService
+            .CheckAssetsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(false));
+
+        restoreService
+            .RestoreAsync(Arg.Any<string>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+
+        graphService
+            .BuildPlanAsync(
+                Arg.Any<ResolvedInput>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<IDiagnosticReporter>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ProjectLoadPlan?>(ValidPlan(ProjectPath)));
+
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService);
+
+        // Act
+        var exitCode = await runner.RunAsync(MakeOptions(restore: true), reporter);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        await restoreService
+            .Received(1)
+            .RestoreAsync(Arg.Any<string>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Typewriter.UnitTests/Typewriter.UnitTests.csproj
+++ b/tests/Typewriter.UnitTests/Typewriter.UnitTests.csproj
@@ -5,6 +5,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.*" />
+    <PackageReference Include="NSubstitute" Version="5.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Add `tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs` with three NSubstitute-mocked acceptance tests for the M3 restore/load pipeline
- Add `NSubstitute 5.*` package reference to `Typewriter.UnitTests.csproj`

## Tests added

| Test | Scenario | Expected |
|------|----------|----------|
| `Csproj_LoadsWithoutRestore_WhenAssetsExist` | Assets present, `--restore false` | Exit 0; `RestoreAsync` NOT called |
| `Csproj_MissingAssetsWithoutRestore_ReturnsTW2003` | Assets missing, `--restore false` | Exit 3; TW2003 emitted |
| `Csproj_WithRestore_LoadsAfterRestore` | Assets missing, `--restore true` | Exit 0; `RestoreAsync` called once |

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] `dotnet test -c Release --filter "FullyQualifiedName~ProjectLoaderTests"` — 3/3 pass
- [x] All three acceptance criteria tests pass

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)