### PR TITLE
feat: add integration test CsprojIntegrationTests (T030)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T027)
+> Last touched: 2026-03-02 by Claude (Executor, T030)
 
 ## Current State
 
@@ -64,6 +64,7 @@
 | T026 Implement IProjectGraphService and ProjectGraphService in Loading.MSBuild (#83) | M3 | Executor | Done | `IProjectGraphService.cs` + `ProjectGraphService.cs` in `src/Typewriter.Loading.MSBuild/`; Kahn's topological sort with path tie-breaker, multi-target selection (TW2401), TFM filtering (TW2002), assets check (TW2003); build 0 errors/warnings |
 | T027 Wire ApplicationRunner to MSBuild loading services (#84) | M3 | Executor | Done | [T027-wire-applicationrunner-to-msbuild.md](.ai/tasks/T027-wire-applicationrunner-to-msbuild.md) — Moved service interfaces to `Typewriter.Application.Loading`; `ApplicationRunner` full pipeline: resolve→restore→graph; `Program.cs` composes concrete services; build 0 errors/warnings, 129/129 tests pass |
 | T029 Add M3 unit tests for ProjectLoader (#85) | M3 | Executor | Done | `tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs` — 3 NSubstitute tests: assets-exist (no restore), missing-assets without restore (TW2003), restore path; NSubstitute 5.x added to test project; all 3 tests pass |
+| T030 Add integration test CsprojIntegrationTests (#86) | M3 | Executor | Done | `tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs` — real-services pipeline test: InputResolver→RestoreService→ProjectGraphService; loads SimpleLib fixture; validates plan.Targets[0].TargetFramework=="net10.0"; MSBuildLocator registered before BuildPlanAsync call; 132/132 tests pass |
 
 ## Decisions
 

--- a/tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs
+++ b/tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs
@@ -1,0 +1,67 @@
+using Typewriter.Application.Diagnostics;
+using Typewriter.Loading.MSBuild;
+using Xunit;
+
+namespace Typewriter.IntegrationTests.Loading;
+
+public class CsprojIntegrationTests
+{
+    private sealed class FakeDiagnosticReporter : IDiagnosticReporter
+    {
+        private int _warningCount;
+        private int _errorCount;
+
+        public void Report(DiagnosticMessage message)
+        {
+            if (message.Severity == DiagnosticSeverity.Warning) _warningCount++;
+            else if (message.Severity == DiagnosticSeverity.Error) _errorCount++;
+        }
+
+        public int WarningCount => _warningCount;
+        public int ErrorCount => _errorCount;
+    }
+
+    [Fact]
+    public async Task SimpleLib_Csproj_ProducesValidProjectLoadPlan()
+    {
+        // Arrange
+        var fixturePath = Path.GetFullPath(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "..", "..", "..", "..", "..",
+                "tests", "fixtures", "SimpleLib", "SimpleLib.csproj"
+            )
+        );
+
+        // Wire real services (no mocks)
+        var locator = new MsBuildLocatorService();
+        var restoreService = new RestoreService();
+        var graphService = new ProjectGraphService(locator);
+        var resolver = new InputResolver();
+        var reporter = new FakeDiagnosticReporter();
+
+        // MSBuildLocator must be registered before any method that JIT-compiles MSBuild
+        // type references is called. RegisterDefaults() sets up the AssemblyResolve handler
+        // so that Microsoft.Build assemblies are resolved from the SDK installation.
+        locator.EnsureRegistered(reporter);
+
+        // Act
+        var resolved = await resolver.ResolveAsync(fixturePath, reporter);
+        Assert.NotNull(resolved);
+
+        // Ensure assets exist (run restore if needed in CI)
+        var hasAssets = await restoreService.CheckAssetsAsync(resolved.ProjectPath);
+        if (!hasAssets)
+        {
+            var restored = await restoreService.RestoreAsync(resolved.ProjectPath, reporter);
+            Assert.True(restored, "dotnet restore failed for SimpleLib fixture");
+        }
+
+        var plan = await graphService.BuildPlanAsync(resolved, null, null, null, reporter);
+
+        // Assert
+        Assert.NotNull(plan);
+        Assert.NotEmpty(plan.Targets);
+        Assert.Equal("net10.0", plan.Targets[0].TargetFramework);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs` with an end-to-end test that runs the full `IInputResolver` → `IRestoreService` → `IProjectGraphService` pipeline using real services (no mocks)
- Test loads the `SimpleLib` fixture project and validates `ProjectLoadPlan` is non-null with a `net10.0` `LoadTarget`
- Calls `MsBuildLocatorService.EnsureRegistered` explicitly before `BuildPlanAsync` to ensure the MSBuild `AssemblyResolve` handler is registered before JIT compilation of MSBuild-dependent code

## Test plan

- [ ] `dotnet restore` succeeds
- [ ] `dotnet build -c Release` — 0 errors, 0 warnings
- [ ] `dotnet test -c Release` — 132/132 tests pass (129 unit + 2 integration + 1 golden)
- [ ] New test `SimpleLib_Csproj_ProducesValidProjectLoadPlan` passes on Linux (verified locally)

## Notes

The integration test explicitly calls `locator.EnsureRegistered(reporter)` before `graphService.BuildPlanAsync(...)`. This is required because `Microsoft.Build` is loaded with `ExcludeAssets="runtime"` and MSBuildLocator's `AssemblyResolve` handler must be registered before the CLR JIT-compiles any method that references `Microsoft.Build` types.

Closes #86
Depends on: #84 (T027), #79 (T028)

🤖 Generated with [Claude Code](https://claude.com/claude-code)