### PR TITLE
chore: verify M3 acceptance criteria (T031)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T030)
+> Last touched: 2026-03-02 by Claude (Executor, T031)
 
 ## Current State
 
-- **Active milestone**: M3 - MSBuild project loading pipeline
+- **Active milestone**: M4 - MSBuild loading: `.sln` and `.slnx`
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Continue M3 — remaining tasks (SolutionGraphService for .sln/.slnx, verify M3 acceptance criteria)
+- **Next step**: Start M4 — SolutionGraphService for `.sln`/`.slnx` loading
 
 ## Milestone Map
 
@@ -16,7 +16,7 @@
 | M0 | Repo bootstrap and packaging skeleton | Done | All acceptance criteria verified: build, test, pack, tool install |
 | M1 | Core reuse extraction (CodeModel/Metadata) | Done | All acceptance criteria verified: build 0 errors, CodeModel 102/102, TypeMapping 71/71, zero VS refs |
 | M2 | CLI contract, diagnostics, and configuration precedence | Done | T013–T018 done: CLI parser, diagnostics infrastructure, config loader, ApplicationRunner validation stub with exit-code mapping; all M2 acceptance tests verified (129/129 pass) |
-| M3 | MSBuild loading: `.csproj` and restore pipeline | In progress | T020 done: NuGet packages added to Loading.MSBuild; restore/build/test verified |
+| M3 | MSBuild loading: `.csproj` and restore pipeline | Done | All acceptance criteria verified: restore/build 0 errors, 133/133 tests pass, origin/ unchanged, zero VS coupling |
 | M4 | MSBuild loading: `.sln` and `.slnx` | Not started | |
 | M5 | Semantic model extraction parity | Not started | |
 | M6 | Template execution and output management | Not started | |
@@ -65,6 +65,7 @@
 | T027 Wire ApplicationRunner to MSBuild loading services (#84) | M3 | Executor | Done | [T027-wire-applicationrunner-to-msbuild.md](.ai/tasks/T027-wire-applicationrunner-to-msbuild.md) — Moved service interfaces to `Typewriter.Application.Loading`; `ApplicationRunner` full pipeline: resolve→restore→graph; `Program.cs` composes concrete services; build 0 errors/warnings, 129/129 tests pass |
 | T029 Add M3 unit tests for ProjectLoader (#85) | M3 | Executor | Done | `tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs` — 3 NSubstitute tests: assets-exist (no restore), missing-assets without restore (TW2003), restore path; NSubstitute 5.x added to test project; all 3 tests pass |
 | T030 Add integration test CsprojIntegrationTests (#86) | M3 | Executor | Done | `tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs` — real-services pipeline test: InputResolver→RestoreService→ProjectGraphService; loads SimpleLib fixture; validates plan.Targets[0].TargetFramework=="net10.0"; MSBuildLocator registered before BuildPlanAsync call; 132/132 tests pass |
+| T031 Run M3 acceptance criteria (#87) | M3 | Executor | Done | [T031-run-m3-acceptance-criteria.md](.ai/tasks/T031-run-m3-acceptance-criteria.md) — restore/build/test all pass; 133/133 tests; 3 M3 unit tests + integration test verified; origin/ unchanged; zero VS coupling |
 
 ## Decisions
 

--- a/.ai/tasks/T031-run-m3-acceptance-criteria.md
+++ b/.ai/tasks/T031-run-m3-acceptance-criteria.md
@@ -1,0 +1,41 @@
+# T031: Run M3 Acceptance Criteria
+- Milestone: M3
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Run mandatory pre-completion verification commands to confirm M3 is complete and all acceptance criteria pass.
+
+## Approach
+Run `dotnet restore`, `dotnet build -c Release`, `dotnet test -c Release`, then verify `origin/` unchanged and no VS coupling in M3 new files.
+
+## Journey
+### 2026-03-02
+- `dotnet restore` — all 11 projects restored successfully (exit 0)
+- `dotnet build -c Release` — 0 errors, 0 warnings (exit 0)
+- `dotnet test -c Release` — all tests pass:
+  - `Typewriter.UnitTests`: 129/129 pass
+    - `ProjectLoaderTests.Csproj_LoadsWithoutRestore_WhenAssetsExist` — PASSED
+    - `ProjectLoaderTests.Csproj_MissingAssetsWithoutRestore_ReturnsTW2003` — PASSED
+    - `ProjectLoaderTests.Csproj_WithRestore_LoadsAfterRestore` — PASSED
+  - `Typewriter.IntegrationTests`: 2/2 pass
+    - `CsprojIntegrationTests.SimpleLib_Csproj_ProducesValidProjectLoadPlan` — PASSED
+  - `Typewriter.GoldenTests`: 1/1 pass
+  - `Typewriter.PerformanceTests`: 1/1 pass
+- `origin/` — no uncommitted changes confirmed via `git status`
+- No VS coupling (`EnvDTE`, `Microsoft.VisualStudio.*`) in `src/Typewriter.Loading.MSBuild/**/*.cs`, `tests/Typewriter.UnitTests/Loading/**/*.cs`, or `tests/Typewriter.IntegrationTests/Loading/**/*.cs`
+
+## Outcome
+All M3 acceptance criteria verified. M3 complete.
+- `dotnet restore` exits 0 ✓
+- `dotnet build -c Release` exits 0, 0 errors, 0 warnings ✓
+- `dotnet test -c Release` exits 0; all 133 tests pass ✓
+- 3 M3 unit tests pass ✓
+- Integration test passes ✓
+- `origin/` unchanged ✓
+- Zero VS coupling in M3 new files ✓
+
+## Follow-ups
+- M4: SolutionGraphService for `.sln`/`.slnx` loading


### PR DESCRIPTION
## Summary

- Ran `dotnet restore`, `dotnet build -c Release`, `dotnet test -c Release` — all pass
- 133/133 tests pass (UnitTests: 129, IntegrationTests: 2, GoldenTests: 1, PerformanceTests: 1)
- 3 M3 unit acceptance tests verified:
  - `ProjectLoaderTests.Csproj_LoadsWithoutRestore_WhenAssetsExist` ✓
  - `ProjectLoaderTests.Csproj_MissingAssetsWithoutRestore_ReturnsTW2003` ✓
  - `ProjectLoaderTests.Csproj_WithRestore_LoadsAfterRestore` ✓
- `CsprojIntegrationTests.SimpleLib_Csproj_ProducesValidProjectLoadPlan` ✓
- `origin/` unchanged (no uncommitted modifications)
- Zero VS coupling (`EnvDTE`, `Microsoft.VisualStudio.*`) in M3 new files
- M3 marked Done; active milestone advanced to M4

Closes #87

## Test plan
- [x] `dotnet restore` exits 0
- [x] `dotnet build -c Release` exits 0, 0 errors, 0 warnings
- [x] `dotnet test -c Release` exits 0, all 133 tests pass
- [x] `origin/` unchanged
- [x] No VS coupling in M3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)