### PR TITLE
docs: update .ai/progress.md — mark M3 done, record M3 decisions and patterns (T032)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-02 by Claude (Executor, T031)
+> Last touched: 2026-03-02 by Claude (Executor, T032)
 
 ## Current State
 
 - **Active milestone**: M4 - MSBuild loading: `.sln` and `.slnx`
-- **Status**: In progress
+- **Status**: Not started
 - **Blocker**: None
-- **Next step**: Start M4 — SolutionGraphService for `.sln`/`.slnx` loading
+- **Next step**: MSBuild loading for `.sln` and `.slnx`
 
 ## Milestone Map
 
@@ -54,14 +54,14 @@
 | T016 Wire --fail-on-warnings and exit-code mapping (#63) | M2 | Executor | Done | [T016-application-runner-stub.md](.ai/tasks/T016-application-runner-stub.md) — `ApplicationRunner.cs` validation stub: empty-templates check, TW1002 for missing solution/project, FailOnWarnings→exit 1; `Placeholder.cs` deleted; 2 new `CliContractTests`; build 0 errors/warnings, 129 tests pass |
 | T017 Add M2 acceptance tests (#64) | M2 | Executor | Done | [T017-m2-acceptance-tests.md](.ai/tasks/T017-m2-acceptance-tests.md) — Verified 4 acceptance tests already in place from T013-T016: `CliContractTests` (2), `DiagnosticFormatTests.MsBuildStyleMessage_IsParseable` (1), `ConfigurationPrecedenceTests.CliOverridesConfigAndTemplate` (1); build 0 errors/warnings, 129 tests pass |
 | T018 Run M2 acceptance criteria (#65) | M2 | Executor | Done | [T018-run-m2-acceptance-criteria.md](.ai/tasks/T018-run-m2-acceptance-criteria.md) — restore/build/test all pass; 129/129 tests pass; origin/ unchanged; zero VS coupling in M2 .cs source files |
-| T020 Add NuGet package refs to Loading.MSBuild (#76) | M3 | Executor | Done | `Microsoft.Build` 17.14.28 + `Microsoft.Build.Locator` 1.11.2 with `ExcludeAssets="runtime"` on Microsoft.Build; restore/build 0 errors, 129/129 tests pass |
+| T020 Add NuGet package refs to Loading.MSBuild (#76) | M3 | Executor | Done | [T020-nuget-refs-loading-msbuild.md](.ai/tasks/T020-nuget-refs-loading-msbuild.md) — `Microsoft.Build 17.*` + `Microsoft.Build.Locator 1.*` with `ExcludeAssets="runtime"`; restore/build 0 errors, 129/129 tests pass |
 | T021 Create bridge DTOs ProjectLoadPlan.cs and LoadTarget.cs (#77) | M3 | Executor | Done | `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` + `LoadTarget.cs`; build 0 errors/warnings |
 | T022 Expand DiagnosticCode.cs with TW2002, TW2003, TW2401 (#78) | M3 | Executor | Done | Added TW2002/TW2003 (Error) + TW2401 (Warning/Info) to `DiagnosticCode.cs`; build 0 errors/warnings |
 | T028 Create test fixture tests/fixtures/SimpleLib/SimpleLib.csproj (#79) | M3 | Executor | Done | `tests/fixtures/SimpleLib/SimpleLib.csproj` + `Class1.cs`; targets net10.0, no Typewriter refs |
 | T023 Implement IInputResolver and ResolvedInput in Loading.MSBuild (#80) | M3 | Executor | Done | `ResolvedInput.cs`, `IInputResolver.cs`, `InputResolver.cs` in `src/Typewriter.Loading.MSBuild/`; inverted dep (Loading.MSBuild → Application); build 0 errors/warnings |
 | T025 Implement MsBuildLocatorService in Loading.MSBuild (#81) | M3 | Executor | Done | `IMsBuildLocatorService.cs` + `MsBuildLocatorService.cs` in `src/Typewriter.Loading.MSBuild/`; Interlocked one-shot guard, TW2001 on failure; build 0 errors/warnings |
 | T024 Implement IRestoreService and RestoreService in Loading.MSBuild (#82) | M3 | Executor | Done | `IRestoreService.cs` + `RestoreService.cs` in `src/Typewriter.Loading.MSBuild/`; CheckAssetsAsync checks obj/project.assets.json, RestoreAsync runs dotnet restore and emits TW2001 on failure; build 0 errors/warnings |
-| T026 Implement IProjectGraphService and ProjectGraphService in Loading.MSBuild (#83) | M3 | Executor | Done | `IProjectGraphService.cs` + `ProjectGraphService.cs` in `src/Typewriter.Loading.MSBuild/`; Kahn's topological sort with path tie-breaker, multi-target selection (TW2401), TFM filtering (TW2002), assets check (TW2003); build 0 errors/warnings |
+| T026 Implement IProjectGraphService and ProjectGraphService in Loading.MSBuild (#83) | M3 | Executor | Done | [T026-project-graph-service.md](.ai/tasks/T026-project-graph-service.md) — `IProjectGraphService.cs` + `ProjectGraphService.cs`; Kahn's topological sort with path tie-breaker, multi-target selection (TW2401), TFM filtering (TW2002), assets check (TW2003); build 0 errors/warnings |
 | T027 Wire ApplicationRunner to MSBuild loading services (#84) | M3 | Executor | Done | [T027-wire-applicationrunner-to-msbuild.md](.ai/tasks/T027-wire-applicationrunner-to-msbuild.md) — Moved service interfaces to `Typewriter.Application.Loading`; `ApplicationRunner` full pipeline: resolve→restore→graph; `Program.cs` composes concrete services; build 0 errors/warnings, 129/129 tests pass |
 | T029 Add M3 unit tests for ProjectLoader (#85) | M3 | Executor | Done | `tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs` — 3 NSubstitute tests: assets-exist (no restore), missing-assets without restore (TW2003), restore path; NSubstitute 5.x added to test project; all 3 tests pass |
 | T030 Add integration test CsprojIntegrationTests (#86) | M3 | Executor | Done | `tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs` — real-services pipeline test: InputResolver→RestoreService→ProjectGraphService; loads SimpleLib fixture; validates plan.Targets[0].TargetFramework=="net10.0"; MSBuildLocator registered before BuildPlanAsync call; 132/132 tests pass |
@@ -78,6 +78,8 @@
 | D-0005 | `ILog`/`Log` omitted from `Settings` abstract class for M1 | 2026-03-02 | Not consumed by CodeModel in M1; will be reconsidered for M2 CLI diagnostics wiring. See T007. |
 | D-0006 | `System.CommandLine` pinned to `2.0.0-beta4.22272.1` | 2026-03-02 | Prerelease 2.x targets `netstandard2.0`, provides stable API shape for the `CommandLineBuilder`+`UseDefaults()` pattern; avoids 1.x→2.x breaking API changes. See T013. |
 | D-0007 | `typewriter.json` discovery stops at `.git` boundary | 2026-03-02 | Upward-walk terminates at the first directory containing `.git/` (repo root) to prevent config files from unrelated parent repos from silently applying. See T015. |
+| D-0008 | `Microsoft.Build` referenced with `ExcludeAssets="runtime"` | 2026-03-02 | MSBuildLocator dynamically loads MSBuild assemblies from the SDK-installed location at runtime; shipping our own copies in the output directory would conflict. Major-wildcard version (`17.*`) avoids lock-step bumps while MSBuildLocator controls the actual DLL resolved. See [T020](tasks/T020-nuget-refs-loading-msbuild.md). |
+| D-0009 | One-shot MSBuild registration guard via `Interlocked.CompareExchange` | 2026-03-02 | `MSBuildLocator.RegisterDefaults()` throws `InvalidOperationException` on a second call in the same process. A static `int _registered` field flipped atomically with `Interlocked.CompareExchange(ref _registered, 1, 0)` makes `EnsureRegistered()` idempotent without locks. See T025. |
 
 ## Open Questions
 
@@ -109,3 +111,6 @@ Note: Q1 (`IncludeProject(name)` ambiguity) was resolved — see `_archive/Q1-in
 - **Agent CI environment**: Install .NET SDK to `/tmp/dotnet` via `dotnet-install.sh` and set `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` on Linux agents without ICU libraries. See T011.
 - **ApplicationRunner stub pattern**: Implement the pipeline orchestrator as a validation-only stub in the milestone that establishes the CLI contract; defer the full load→metadata→render→write pipeline to the milestone that delivers the required dependencies. Allows acceptance tests to pass immediately. See T016.
 - **IDiagnosticReporter injection**: Pass `IDiagnosticReporter` into `RunAsync()` rather than the constructor so each invocation gets a fresh reporter; use a `FakeDiagnosticReporter` with pre-seeded counts in unit tests to verify `--fail-on-warnings` without real console output. See T016.
+- **MsBuildLocatorService one-shot guard**: Use `static int _registered` + `Interlocked.CompareExchange(ref _registered, 1, 0) == 0` to make any single-call-only MSBuild registration idempotent; first caller registers, subsequent callers are silently no-ops. See T025, D-0009.
+- **`dotnet restore` stderr capture convention**: Spawn `dotnet restore <path>` with `RedirectStandardError=true`; capture `StandardError.ReadToEndAsync()` before `WaitForExitAsync()`; on non-zero exit, emit TW2001 with the stderr body trimmed. See T024 (`RestoreService.cs`).
+- **`project.assets.json` presence check convention**: Existence of `<project-dir>/obj/project.assets.json` is the canonical indicator of a successful restore; checked by both `RestoreService.CheckAssetsAsync` and `ProjectGraphService.BuildPlanAsync` to emit TW2003 when missing. See T024/T026.

--- a/.ai/tasks/T020-nuget-refs-loading-msbuild.md
+++ b/.ai/tasks/T020-nuget-refs-loading-msbuild.md
@@ -1,0 +1,33 @@
+# T020: Add NuGet Package Refs to Loading.MSBuild
+- Milestone: M3
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Add `Microsoft.Build` and `Microsoft.Build.Locator` NuGet references to `src/Typewriter.Loading.MSBuild/Typewriter.Loading.MSBuild.csproj` so the project can load MSBuild project graphs without shipping conflicting MSBuild assemblies.
+
+## Approach
+Add both packages with a major-wildcard version constraint and apply `ExcludeAssets="runtime"` to `Microsoft.Build` so the MSBuild assemblies are not copied to the output directory — MSBuildLocator loads them at runtime from the SDK-installed location.
+
+Key file: `src/Typewriter.Loading.MSBuild/Typewriter.Loading.MSBuild.csproj`
+
+## Journey
+### 2026-03-02
+- Looked at `Microsoft.Build.Locator` docs: `RegisterDefaults()` must be called before any `Microsoft.Build.*` type is loaded. If the Microsoft.Build assemblies are in the output directory, the CLR may load them before `RegisterDefaults()` is called, causing version conflicts.
+- The correct pattern is `ExcludeAssets="runtime"` on the `Microsoft.Build` reference so only the compile-time reference is present; at runtime MSBuildLocator resolves the correct version from the SDK.
+- Chose major-wildcard versions (`17.*` for Microsoft.Build, `1.*` for Microsoft.Build.Locator) rather than pinning exact patch versions. This prevents lock-step bumps for every MSBuild SDK patch while MSBuildLocator still controls which DLL is actually loaded at runtime.
+- Added inline XML comment explaining the `ExcludeAssets="runtime"` rationale for future maintainers.
+- `dotnet restore` resolved successfully; `dotnet build -c Release` 0 errors, 0 warnings; 129/129 tests pass.
+
+## Outcome
+`Typewriter.Loading.MSBuild.csproj` contains:
+```xml
+<PackageReference Include="Microsoft.Build" Version="17.*" ExcludeAssets="runtime" />
+<PackageReference Include="Microsoft.Build.Locator" Version="1.*" />
+```
+Build and test pass. See D-0008 for the formal decision record.
+
+## Follow-ups
+- T025: implement `MsBuildLocatorService` with the one-shot guard that calls `MSBuildLocator.RegisterDefaults()` exactly once per process (see D-0009).

--- a/.ai/tasks/T026-project-graph-service.md
+++ b/.ai/tasks/T026-project-graph-service.md
@@ -1,0 +1,57 @@
+# T026: Implement IProjectGraphService and ProjectGraphService
+- Milestone: M3
+- Status: Done
+- Agent: Claude (Executor)
+- Started: 2026-03-02
+- Completed: 2026-03-02
+
+## Objective
+Implement `IProjectGraphService` and `ProjectGraphService` in `src/Typewriter.Loading.MSBuild/` to load an MSBuild `ProjectGraph`, perform deterministic topological sort of nodes, select target frameworks, verify restore assets, and produce a `ProjectLoadPlan`.
+
+## Approach
+Files involved:
+- `src/Typewriter.Loading.MSBuild/IProjectGraphService.cs` (interface)
+- `src/Typewriter.Loading.MSBuild/ProjectGraphService.cs` (implementation)
+- `src/Typewriter.Application/Loading/IProjectGraphService.cs` (interface moved here during T027)
+- `src/Typewriter.Application/Orchestration/ProjectLoadPlan.cs` (output DTO, from T021)
+- `src/Typewriter.Application/Orchestration/LoadTarget.cs` (target DTO, from T021)
+
+## Journey
+### 2026-03-02 — Core implementation
+
+**Topological sort decision (Kahn's algorithm with path tie-breaker)**
+
+`ProjectGraph.ProjectNodes` returns nodes in no guaranteed order. Output ordering must be deterministic (see AGENTS.md §2.7) so that later stages (metadata extraction, code generation) produce stable results regardless of filesystem or evaluation order.
+
+Chose Kahn's algorithm (BFS-based topological sort) over DFS because:
+- Natural dependencies-first ordering: libraries are emitted before their consumers, which is the correct load order for Roslyn workspace building.
+- Cycle detection is trivial (graph leftover after sort).
+- Tie-breaking between ready nodes at each step is straightforward: sort by `FullPath` ascending (ordinal) to get deterministic alphabetical ordering within the same dependency depth.
+
+Implementation uses a `SortedSet<ProjectGraphNode>` keyed by `FullPath` as the "available" queue. At each step `available.Min` is the lexicographically smallest ready node, ensuring a fully deterministic traversal even when multiple nodes have the same in-degree.
+
+**Multi-target framework selection**
+
+When a project declares `<TargetFrameworks>` (plural, semicolon-separated), MSBuild evaluates it as a single TFM-agnostic instance in the `ProjectGraph`. The selected TFM must be determined explicitly:
+- If `--framework` is supplied: validate it is present in the declared list; emit TW2002 error if not.
+- If `--framework` is absent: default to `tfms[0]` (first declared TFM in document order) and emit a TW2401 informational diagnostic listing all TFMs and advising `--framework`. This preserves determinism (no "random" TFM picked) while informing the user they may want to narrow scope.
+
+**Restore assets check**
+
+`ProjectGraphService.BuildPlanAsync` re-checks `obj/project.assets.json` presence for each node after topological sort. This is a second guard beyond `RestoreService.CheckAssetsAsync` (which checks the root project before the restore decision is made). The in-graph check catches projects that were reachable via `ProjectReference` chains but whose assets were not restored (e.g., added to the solution after the last restore). Emits TW2003 error.
+
+**Error accumulation**
+
+Errors for individual nodes (`TW2002` missing TFM, `TW2003` missing assets) are accumulated across all nodes before returning `null`; this surfaces all problems in one pass rather than short-circuiting on the first node failure.
+
+## Outcome
+`ProjectGraphService` produces a `ProjectLoadPlan` with:
+- `Targets` in topological (dependencies-first) order, deterministically sorted by path within each level.
+- Each `LoadTarget` carries `TargetFramework`, `Configuration`, `RuntimeIdentifier`, and a zero-based `Index`.
+- Returns `null` on any error; all errors reported via `IDiagnosticReporter` before returning.
+
+Tests in `tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs` (T029) and `tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs` (T030) cover the main paths.
+
+## Follow-ups
+- M4: extend `IProjectGraphService` or add `ISolutionGraphService` for `.sln` / `.slnx` inputs.
+- `ProjectGraph` does not natively support `.sln` files; M4 will need to enumerate solution projects and construct the graph manually.


### PR DESCRIPTION
## Summary

- Marks M3 as Done in the Milestone Map (already done by T031, this PR adds the formal decision/pattern records)
- Sets Current State status to **Not started** for M4 (was incorrectly showing "In progress")
- Adds D-0008 (`ExcludeAssets="runtime"` strategy for `Microsoft.Build`) and D-0009 (one-shot MSBuild registration guard) to the Decisions table
- Adds 3 new patterns: `MsBuildLocatorService` one-shot guard, `dotnet restore` stderr capture convention, `project.assets.json` presence check convention
- Creates per-task detail files for T020 (NuGet refs / version pinning) and T026 (Kahn's topological sort, multi-TFM selection)
- Updates T020 and T026 Active Tasks rows to link to the new detail files

Closes #88

## Test plan

- [ ] No code changes — docs-only; exempt from mandatory pre-completion verification per AGENTS.md §8
- [ ] `.ai/progress.md` shows M3 Done, M4 Not started ✓
- [ ] All M3 task rows present with status Done ✓
- [ ] D-0008, D-0009 decision records added ✓
- [ ] Three new patterns recorded ✓
- [ ] T020 and T026 task detail files created ✓
- [ ] No milestone scope or acceptance criteria duplicated from `DETAILED_IMPLEMENTATION_PLAN.md` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)