### PR TITLE
feat: add eng/versioning.props with MinVer config (M8)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -21,7 +21,7 @@
 | M5 | Semantic model extraction parity | Not started | |
 | M6 | Template execution and output management | Not started | |
 | M7 | Golden parity and fixture repos | Not started | |
-| M8 | CI pipelines and release readiness | Not started | |
+| M8 | CI pipelines and release readiness | In progress | eng/versioning.props created (#166) |
 | M9 | Performance and caching hardening | Not started | |
 
 ## Active Tasks

--- a/eng/versioning.props
+++ b/eng/versioning.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Creates `eng/versioning.props` with MinVer configuration for tag-based semantic versioning
- Sets `MinVerDefaultPreReleasePhase` to `preview` and `MinVerTagPrefix` to `v`
- Creates the `eng/` directory (did not previously exist)

## What changed
- **`eng/versioning.props`** (new): Valid MSBuild XML file with MinVer property group; will be imported by `Directory.Build.props` in a follow-up task

## Test plan
- [ ] Verify `eng/versioning.props` is valid MSBuild XML (file parses cleanly)
- [ ] Verify file is committed to the repository

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)