### PR TITLE
feat: add ISolutionFallbackService interface (M4)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -67,6 +67,7 @@
 | T030 Add integration test CsprojIntegrationTests (#86) | M3 | Executor | Done | `tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs` — real-services pipeline test: InputResolver→RestoreService→ProjectGraphService; loads SimpleLib fixture; validates plan.Targets[0].TargetFramework=="net10.0"; MSBuildLocator registered before BuildPlanAsync call; 132/132 tests pass |
 | T031 Run M3 acceptance criteria (#87) | M3 | Executor | Done | [T031-run-m3-acceptance-criteria.md](.ai/tasks/T031-run-m3-acceptance-criteria.md) — restore/build/test all pass; 133/133 tests; 3 M3 unit tests + integration test verified; origin/ unchanged; zero VS coupling |
 | #115 Add TW2110 and TW2310 to DiagnosticCode.cs | M4 | Executor | Done | Added TW2110 (Error, ProjectGraph sln/slnx load failure) and TW2310 (Warning, SolutionFallbackService slnx list failure); build 0 errors/warnings |
+| #116 Create ISolutionFallbackService interface | M4 | Executor | Done | `src/Typewriter.Application/Loading/ISolutionFallbackService.cs`; ListProjectPathsAsync signature matches spec; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Application/Loading/ISolutionFallbackService.cs
+++ b/src/Typewriter.Application/Loading/ISolutionFallbackService.cs
@@ -1,0 +1,8 @@
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.Application.Loading;
+
+public interface ISolutionFallbackService
+{
+    Task<IReadOnlyList<string>?> ListProjectPathsAsync(string slnxPath, IDiagnosticReporter reporter, CancellationToken ct);
+}


### PR DESCRIPTION
## Summary

- Adds `ISolutionFallbackService` to `src/Typewriter.Application/Loading/ISolutionFallbackService.cs`
- Method signature: `Task<IReadOnlyList<string>?> ListProjectPathsAsync(string slnxPath, IDiagnosticReporter reporter, CancellationToken ct)`
- Follows the established M3 pattern (see `IInputResolver.cs`)
- `dotnet build -c Release` succeeds with 0 errors, 0 warnings

## Test plan

- [x] `dotnet build -c Release` passes (0 errors, 0 warnings)
- [ ] Implementation in `Typewriter.Loading.MSBuild` (separate task)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)