### PR TITLE
feat: update InputResolver to accept .sln and .slnx extensions (M4)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -68,6 +68,7 @@
 | T031 Run M3 acceptance criteria (#87) | M3 | Executor | Done | [T031-run-m3-acceptance-criteria.md](.ai/tasks/T031-run-m3-acceptance-criteria.md) — restore/build/test all pass; 133/133 tests; 3 M3 unit tests + integration test verified; origin/ unchanged; zero VS coupling |
 | #115 Add TW2110 and TW2310 to DiagnosticCode.cs | M4 | Executor | Done | Added TW2110 (Error, ProjectGraph sln/slnx load failure) and TW2310 (Warning, SolutionFallbackService slnx list failure); build 0 errors/warnings |
 | #116 Create ISolutionFallbackService interface | M4 | Executor | Done | `src/Typewriter.Application/Loading/ISolutionFallbackService.cs`; ListProjectPathsAsync signature matches spec; build 0 errors/warnings |
+| #117 Update InputResolver to accept .sln and .slnx | M4 | Executor | Done | Added explicit extension validation (.csproj/.sln/.slnx accepted, others TW2002); `InputResolverTests.cs` 7 new tests; 140 tests pass |
 
 ## Decisions
 

--- a/src/Typewriter.Loading.MSBuild/InputResolver.cs
+++ b/src/Typewriter.Loading.MSBuild/InputResolver.cs
@@ -5,6 +5,10 @@ namespace Typewriter.Loading.MSBuild;
 
 public sealed class InputResolver : IInputResolver
 {
+    // Accepted input file extensions: .csproj, .sln, .slnx
+    private static readonly HashSet<string> AcceptedExtensions =
+        new(StringComparer.OrdinalIgnoreCase) { ".csproj", ".sln", ".slnx" };
+
     public Task<ResolvedInput?> ResolveAsync(
         string projectPath,
         IDiagnosticReporter reporter,
@@ -21,12 +25,23 @@ public sealed class InputResolver : IInputResolver
         expanded = Environment.ExpandEnvironmentVariables(expanded);
         string resolvedPath = Path.GetFullPath(expanded);
 
+        string ext = Path.GetExtension(resolvedPath);
+        if (!AcceptedExtensions.Contains(ext))
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                DiagnosticCode.TW2002,
+                $"Unsupported file extension '{ext}'. Accepted: .csproj, .sln, .slnx",
+                File: resolvedPath));
+            return Task.FromResult<ResolvedInput?>(null);
+        }
+
         if (!File.Exists(resolvedPath))
         {
             reporter.Report(new DiagnosticMessage(
                 DiagnosticSeverity.Error,
                 DiagnosticCode.TW2002,
-                $"Project file not found: '{resolvedPath}'",
+                $"Input file not found: '{resolvedPath}'",
                 File: resolvedPath));
             return Task.FromResult<ResolvedInput?>(null);
         }

--- a/tests/Typewriter.UnitTests/Loading/InputResolverTests.cs
+++ b/tests/Typewriter.UnitTests/Loading/InputResolverTests.cs
@@ -1,0 +1,88 @@
+using NSubstitute;
+using Typewriter.Application.Diagnostics;
+using Typewriter.Loading.MSBuild;
+using Xunit;
+
+namespace Typewriter.UnitTests.Loading;
+
+public class InputResolverTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var f in _tempFiles)
+        {
+            if (File.Exists(f)) File.Delete(f);
+        }
+    }
+
+    private string CreateTempFile(string extension)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"tw_test_{Guid.NewGuid():N}{extension}");
+        File.WriteAllText(path, string.Empty);
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".sln")]
+    [InlineData(".slnx")]
+    public async Task AcceptedExtensions_ExistingFile_ReturnsResolvedInput(string extension)
+    {
+        var reporter = Substitute.For<IDiagnosticReporter>();
+        var resolver = new InputResolver();
+        string path = CreateTempFile(extension);
+
+        var result = await resolver.ResolveAsync(path, reporter);
+
+        Assert.NotNull(result);
+        Assert.Equal(path, result.ProjectPath);
+        reporter.DidNotReceive().Report(Arg.Any<DiagnosticMessage>());
+    }
+
+    [Theory]
+    [InlineData(".sln")]
+    [InlineData(".slnx")]
+    public async Task SlnAndSlnx_NonExistentFile_EmitsTW2002(string extension)
+    {
+        var reporter = Substitute.For<IDiagnosticReporter>();
+        var resolver = new InputResolver();
+        string path = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid():N}{extension}");
+
+        var result = await resolver.ResolveAsync(path, reporter);
+
+        Assert.Null(result);
+        reporter.Received(1).Report(Arg.Is<DiagnosticMessage>(
+            m => m.Code == DiagnosticCode.TW2002 && m.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public async Task Csproj_NonExistentFile_EmitsTW2002()
+    {
+        var reporter = Substitute.For<IDiagnosticReporter>();
+        var resolver = new InputResolver();
+        string path = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid():N}.csproj");
+
+        var result = await resolver.ResolveAsync(path, reporter);
+
+        Assert.Null(result);
+        reporter.Received(1).Report(Arg.Is<DiagnosticMessage>(
+            m => m.Code == DiagnosticCode.TW2002 && m.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public async Task UnsupportedExtension_EmitsTW2002()
+    {
+        var reporter = Substitute.For<IDiagnosticReporter>();
+        var resolver = new InputResolver();
+        string path = CreateTempFile(".txt");
+
+        var result = await resolver.ResolveAsync(path, reporter);
+
+        Assert.Null(result);
+        reporter.Received(1).Report(Arg.Is<DiagnosticMessage>(
+            m => m.Code == DiagnosticCode.TW2002 && m.Severity == DiagnosticSeverity.Error));
+    }
+}


### PR DESCRIPTION
## Summary

- Added explicit extension validation in `InputResolver.ResolveAsync`: `.csproj`, `.sln`, and `.slnx` are accepted; any other extension emits TW2002 before the file-existence check.
- Existing `.csproj` accept/reject behaviour is fully preserved.
- Added `InputResolverTests.cs` with 7 unit tests covering: all three accepted extensions with existing files, non-existent `.sln`/`.slnx` paths (→ TW2002), missing `.csproj` (→ TW2002), and unsupported extension (→ TW2002).

Closes #117

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] `dotnet test -c Release` — 140/140 pass (7 new `InputResolverTests` + all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)