### PR TITLE
feat: add solution-sln test fixture (M4, #118)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -69,6 +69,7 @@
 | #115 Add TW2110 and TW2310 to DiagnosticCode.cs | M4 | Executor | Done | Added TW2110 (Error, ProjectGraph sln/slnx load failure) and TW2310 (Warning, SolutionFallbackService slnx list failure); build 0 errors/warnings |
 | #116 Create ISolutionFallbackService interface | M4 | Executor | Done | `src/Typewriter.Application/Loading/ISolutionFallbackService.cs`; ListProjectPathsAsync signature matches spec; build 0 errors/warnings |
 | #117 Update InputResolver to accept .sln and .slnx | M4 | Executor | Done | Added explicit extension validation (.csproj/.sln/.slnx accepted, others TW2002); `InputResolverTests.cs` 7 new tests; 140 tests pass |
+| #118 Create solution-sln test fixture | M4 | Executor | Done | `tests/fixtures/solution-sln/SolutionSln.sln` + ProjectA + ProjectB; targets net10.0; `dotnet sln list` and `dotnet restore` verified |
 
 ## Decisions
 

--- a/tests/fixtures/solution-sln/ProjectA/Class1.cs
+++ b/tests/fixtures/solution-sln/ProjectA/Class1.cs
@@ -1,0 +1,3 @@
+namespace ProjectA;
+
+public class Class1 { }

--- a/tests/fixtures/solution-sln/ProjectA/ProjectA.csproj
+++ b/tests/fixtures/solution-sln/ProjectA/ProjectA.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/fixtures/solution-sln/ProjectB/Class1.cs
+++ b/tests/fixtures/solution-sln/ProjectB/Class1.cs
@@ -1,0 +1,3 @@
+namespace ProjectB;
+
+public class Class1 { }

--- a/tests/fixtures/solution-sln/ProjectB/ProjectB.csproj
+++ b/tests/fixtures/solution-sln/ProjectB/ProjectB.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/fixtures/solution-sln/SolutionSln.sln
+++ b/tests/fixtures/solution-sln/SolutionSln.sln
@@ -1,0 +1,28 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectA", "ProjectA\ProjectA.csproj", "{A1B2C3D4-0001-0001-0001-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectB", "ProjectB\ProjectB.csproj", "{A1B2C3D4-0002-0002-0002-000000000002}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-0001-0001-0001-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-0001-0001-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-0001-0001-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-0001-0001-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-0002-0002-0002-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0002-0002-0002-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0002-0002-0002-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0002-0002-0002-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- Creates `tests/fixtures/solution-sln/SolutionSln.sln` — VS solution file referencing ProjectA and ProjectB
- Creates `tests/fixtures/solution-sln/ProjectA/ProjectA.csproj` + `Class1.cs` (net10.0)
- Creates `tests/fixtures/solution-sln/ProjectB/ProjectB.csproj` + `Class1.cs` (net10.0)
- Updates `.ai/progress.md` to record task #118 as Done

## Acceptance criteria verified
- `dotnet sln tests/fixtures/solution-sln/SolutionSln.sln list` outputs `ProjectA/ProjectA.csproj` and `ProjectB/ProjectB.csproj`
- Both projects target `net10.0`
- `dotnet restore tests/fixtures/solution-sln/SolutionSln.sln` succeeds (both projects restored)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)