### PR TITLE
feat: add SolutionFallbackService for dotnet sln list fallback (M4, #119)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -70,6 +70,7 @@
 | #116 Create ISolutionFallbackService interface | M4 | Executor | Done | `src/Typewriter.Application/Loading/ISolutionFallbackService.cs`; ListProjectPathsAsync signature matches spec; build 0 errors/warnings |
 | #117 Update InputResolver to accept .sln and .slnx | M4 | Executor | Done | Added explicit extension validation (.csproj/.sln/.slnx accepted, others TW2002); `InputResolverTests.cs` 7 new tests; 140 tests pass |
 | #118 Create solution-sln test fixture | M4 | Executor | Done | `tests/fixtures/solution-sln/SolutionSln.sln` + ProjectA + ProjectB; targets net10.0; `dotnet sln list` and `dotnet restore` verified |
+| #119 Implement SolutionFallbackService | M4 | Executor | Done | `src/Typewriter.Loading.MSBuild/SolutionFallbackService.cs`; implements ISolutionFallbackService; spawns `dotnet sln <path> list`, parses stdout, resolves relative→absolute paths; TW2310 on non-zero exit; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Loading.MSBuild/SolutionFallbackService.cs
+++ b/src/Typewriter.Loading.MSBuild/SolutionFallbackService.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
+
+namespace Typewriter.Loading.MSBuild;
+
+public sealed class SolutionFallbackService : ISolutionFallbackService
+{
+    public async Task<IReadOnlyList<string>?> ListProjectPathsAsync(string slnxPath, IDiagnosticReporter reporter, CancellationToken ct)
+    {
+        var solutionDir = Path.GetDirectoryName(Path.GetFullPath(slnxPath))!;
+
+        var psi = new ProcessStartInfo("dotnet", $"sln \"{slnxPath}\" list")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        var stdout = await process.StandardOutput.ReadToEndAsync(ct);
+        var stderr = await process.StandardError.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+
+        if (process.ExitCode != 0)
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Warning,
+                DiagnosticCode.TW2310,
+                $"dotnet sln list failed for '{slnxPath}':{(string.IsNullOrWhiteSpace(stderr) ? string.Empty : $"\n{stderr.TrimEnd()}")}"));
+            return null;
+        }
+
+        var paths = new List<string>();
+        foreach (var line in stdout.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("Project(s)", StringComparison.Ordinal) || trimmed.All(c => c == '-'))
+                continue;
+
+            paths.Add(Path.GetFullPath(trimmed, solutionDir));
+        }
+
+        return paths;
+    }
+}


### PR DESCRIPTION
## What changed

- New file: `src/Typewriter.Loading.MSBuild/SolutionFallbackService.cs`
- Implements `ISolutionFallbackService` from `Typewriter.Application.Loading`
- Spawns `dotnet sln <slnxPath> list` via `System.Diagnostics.Process` (cross-platform)
- Reads stdout line-by-line, skipping the header/separator lines produced by `dotnet sln list`
- Resolves each relative path to absolute using `Path.GetFullPath(relative, solutionDir)`
- On non-zero exit: emits `TW2310` (Warning) via `IDiagnosticReporter` and returns `null`
- Updates `.ai/progress.md` task log for #119

## Why

Provides the fallback path for when MSBuild `ProjectGraph` fails to load a `.slnx` solution file. Without this service, `.slnx` failures would leave the loader with no project list to process.

## Verification

- `dotnet build -c Release` — 0 errors, 0 warnings

Closes #119