### PR TITLE
feat: add solution-slnx test fixture (M4, #120)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -71,6 +71,7 @@
 | #117 Update InputResolver to accept .sln and .slnx | M4 | Executor | Done | Added explicit extension validation (.csproj/.sln/.slnx accepted, others TW2002); `InputResolverTests.cs` 7 new tests; 140 tests pass |
 | #118 Create solution-sln test fixture | M4 | Executor | Done | `tests/fixtures/solution-sln/SolutionSln.sln` + ProjectA + ProjectB; targets net10.0; `dotnet sln list` and `dotnet restore` verified |
 | #119 Implement SolutionFallbackService | M4 | Executor | Done | `src/Typewriter.Loading.MSBuild/SolutionFallbackService.cs`; implements ISolutionFallbackService; spawns `dotnet sln <path> list`, parses stdout, resolves relative→absolute paths; TW2310 on non-zero exit; build 0 errors/warnings |
+| #120 Create solution-slnx test fixture | M4 | Executor | Done | `tests/fixtures/solution-slnx/SolutionSlnx.slnx` + independent ProjectA + ProjectB copies (Option B); valid XML; targets net10.0 |
 
 ## Decisions
 

--- a/tests/fixtures/solution-slnx/ProjectA/Class1.cs
+++ b/tests/fixtures/solution-slnx/ProjectA/Class1.cs
@@ -1,0 +1,3 @@
+namespace ProjectA;
+
+public class Class1 { }

--- a/tests/fixtures/solution-slnx/ProjectA/ProjectA.csproj
+++ b/tests/fixtures/solution-slnx/ProjectA/ProjectA.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/fixtures/solution-slnx/ProjectB/Class1.cs
+++ b/tests/fixtures/solution-slnx/ProjectB/Class1.cs
@@ -1,0 +1,3 @@
+namespace ProjectB;
+
+public class Class1 { }

--- a/tests/fixtures/solution-slnx/ProjectB/ProjectB.csproj
+++ b/tests/fixtures/solution-slnx/ProjectB/ProjectB.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/fixtures/solution-slnx/SolutionSlnx.slnx
+++ b/tests/fixtures/solution-slnx/SolutionSlnx.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="ProjectA/ProjectA.csproj" />
+  <Project Path="ProjectB/ProjectB.csproj" />
+</Solution>


### PR DESCRIPTION
## Summary
- Creates `tests/fixtures/solution-slnx/SolutionSlnx.slnx` — valid XML in `<Solution><Project Path="..." /></Solution>` format referencing ProjectA and ProjectB
- Creates independent copies of ProjectA and ProjectB under `tests/fixtures/solution-slnx/` (Option B for fixture isolation)
- Both projects target `net10.0` with nullable/implicit-usings enabled

## What changed
- `tests/fixtures/solution-slnx/SolutionSlnx.slnx` — `.slnx` fixture file
- `tests/fixtures/solution-slnx/ProjectA/ProjectA.csproj` + `Class1.cs`
- `tests/fixtures/solution-slnx/ProjectB/ProjectB.csproj` + `Class1.cs`
- `.ai/progress.md` updated with task #120 completion

## Test plan
- [ ] File parses as valid XML
- [ ] `SolutionFallbackService` can extract both project paths from `SolutionSlnx.slnx`
- [ ] `dotnet restore` succeeds on both referenced projects
- [ ] Fixture is independent of `solution-sln/` — no cross-fixture path references

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)