### PR TITLE
feat: compose SolutionFallbackService in Program.cs (M4, #122)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M4 - MSBuild loading: `.sln` and `.slnx`
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Implement SolutionFallbackService and ProjectGraph sln/slnx loading
+- **Next step**: Implement sln/slnx loading logic in ProjectGraphService using SolutionFallbackService
 
 ## Milestone Map
 
@@ -72,6 +72,7 @@
 | #118 Create solution-sln test fixture | M4 | Executor | Done | `tests/fixtures/solution-sln/SolutionSln.sln` + ProjectA + ProjectB; targets net10.0; `dotnet sln list` and `dotnet restore` verified |
 | #119 Implement SolutionFallbackService | M4 | Executor | Done | `src/Typewriter.Loading.MSBuild/SolutionFallbackService.cs`; implements ISolutionFallbackService; spawns `dotnet sln <path> list`, parses stdout, resolves relative→absolute paths; TW2310 on non-zero exit; build 0 errors/warnings |
 | #120 Create solution-slnx test fixture | M4 | Executor | Done | `tests/fixtures/solution-slnx/SolutionSlnx.slnx` + independent ProjectA + ProjectB copies (Option B); valid XML; targets net10.0 |
+| #122 Compose SolutionFallbackService in Program.cs | M4 | Executor | Done | `ProjectGraphService` constructor updated to accept `ISolutionFallbackService`; `Program.cs` instantiates `SolutionFallbackService` and passes it in; `CsprojIntegrationTests` updated to match new ctor signature |
 
 ## Decisions
 

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -59,7 +59,8 @@ generateCommand.SetHandler(async (InvocationContext ctx) =>
     var locatorService = new MsBuildLocatorService();
     var inputResolver = new InputResolver();
     var restoreService = new RestoreService();
-    var projectGraphService = new ProjectGraphService(locatorService);
+    var solutionFallbackService = new SolutionFallbackService();
+    var projectGraphService = new ProjectGraphService(locatorService, solutionFallbackService);
 
     var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService);
     ctx.ExitCode = await runner.RunAsync(options, reporter, ctx.GetCancellationToken());

--- a/src/Typewriter.Loading.MSBuild/ProjectGraphService.cs
+++ b/src/Typewriter.Loading.MSBuild/ProjectGraphService.cs
@@ -8,10 +8,12 @@ namespace Typewriter.Loading.MSBuild;
 public sealed class ProjectGraphService : IProjectGraphService
 {
     private readonly IMsBuildLocatorService _locatorService;
+    private readonly ISolutionFallbackService _solutionFallbackService;
 
-    public ProjectGraphService(IMsBuildLocatorService locatorService)
+    public ProjectGraphService(IMsBuildLocatorService locatorService, ISolutionFallbackService solutionFallbackService)
     {
         _locatorService = locatorService;
+        _solutionFallbackService = solutionFallbackService;
     }
 
     public Task<ProjectLoadPlan?> BuildPlanAsync(

--- a/tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs
+++ b/tests/Typewriter.IntegrationTests/Loading/CsprojIntegrationTests.cs
@@ -36,7 +36,8 @@ public class CsprojIntegrationTests
         // Wire real services (no mocks)
         var locator = new MsBuildLocatorService();
         var restoreService = new RestoreService();
-        var graphService = new ProjectGraphService(locator);
+        var solutionFallbackService = new SolutionFallbackService();
+        var graphService = new ProjectGraphService(locator, solutionFallbackService);
         var resolver = new InputResolver();
         var reporter = new FakeDiagnosticReporter();
 


### PR DESCRIPTION
## Summary

- Add `ISolutionFallbackService` parameter to `ProjectGraphService` constructor and store it as a private field
- Instantiate `SolutionFallbackService` in `Program.cs` composition root following the established service ordering: `MsBuildLocatorService` → `InputResolver` → `RestoreService` → `SolutionFallbackService` → `ProjectGraphService`
- Update `CsprojIntegrationTests` to supply `SolutionFallbackService` to the updated `ProjectGraphService` constructor

## Test plan

- [ ] `dotnet build -c Release` succeeds (no new compilation errors)
- [ ] Existing `CsprojIntegrationTests.SimpleLib_Csproj_ProducesValidProjectLoadPlan` still passes with the updated constructor call
- [ ] All existing unit tests in `ProjectLoaderTests` continue to pass (they use NSubstitute mocks for `IProjectGraphService`, unaffected by constructor changes)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)