### PR TITLE
feat: add TW2200–TW2205 workspace diagnostic codes (M5)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M5 - Semantic model extraction parity
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Begin M5 semantic model extraction implementation
+- **Next step**: Implement Roslyn workspace loading services using TW2200–TW2205 codes
 
 ## Milestone Map
 
@@ -76,6 +76,7 @@
 | #122 Compose SolutionFallbackService in Program.cs | M4 | Executor | Done | `ProjectGraphService` constructor updated to accept `ISolutionFallbackService`; `Program.cs` instantiates `SolutionFallbackService` and passes it in; `CsprojIntegrationTests` updated to match new ctor signature |
 | #123 Add SolutionLoaderTests integration tests | M4 | Executor | Done | `SolutionLoader.cs` + `SolutionLoaderTests.cs`; 4 tests: Sln_LoadsExpectedProjects, Slnx_LoadsExpectedProjects, SlnAndSlnx_ProduceSameTraversalPlan, Slnx_WhenGraphFails_UsesFallback; TW2110/TW2310 exercised |
 | #124 Run M4 acceptance criteria verification | M4 | Executor | Done | restore/build/test all pass; 150/150 tests; all 4 SolutionLoaderTests green; TW2310 test added (`SolutionFallbackService_NonExistentSolution_EmitsTW2310`); origin/ unchanged; zero VS coupling |
+| #125 Add TW2200–TW2205 workspace diagnostic codes | M5 | Executor | Done | Added TW2200 (Error, workspace load failure), TW2201 (Warning, non-fatal workspace diagnostic), TW2202 (Error, compilation failure), TW2203 (Error, project not found), TW2204 (Error, unresolved project reference), TW2205 (Warning, partial documents); build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Application/Diagnostics/DiagnosticCode.cs
+++ b/src/Typewriter.Application/Diagnostics/DiagnosticCode.cs
@@ -20,6 +20,24 @@ public static class DiagnosticCode
     /// <summary>(Error) MSBuild ProjectGraph constructor failed to load a .sln or .slnx solution file.</summary>
     public const string TW2110 = "TW2110";
 
+    /// <summary>(Error) General workspace load failure: MSBuildWorkspace emitted a diagnostic with error severity during workspace creation or project open.</summary>
+    public const string TW2200 = "TW2200";
+
+    /// <summary>(Warning) Non-fatal workspace diagnostic emitted during project open; generation may continue but output could be incomplete.</summary>
+    public const string TW2201 = "TW2201";
+
+    /// <summary>(Error) Compilation failure: the Roslyn compilation for a project was null or contained error-severity diagnostics that prevent semantic extraction.</summary>
+    public const string TW2202 = "TW2202";
+
+    /// <summary>(Error) Project not found in workspace after OpenProjectAsync completed; the workspace did not contain the expected project entry.</summary>
+    public const string TW2203 = "TW2203";
+
+    /// <summary>(Error) Workspace project reference could not be resolved; one or more project-to-project references are missing from the loaded workspace graph.</summary>
+    public const string TW2204 = "TW2204";
+
+    /// <summary>(Warning) Workspace loaded with partial documents; one or more source files were excluded or failed to open, which may affect metadata completeness.</summary>
+    public const string TW2205 = "TW2205";
+
     /// <summary>(Warning) SolutionFallbackService could not list projects from a .slnx file via dotnet sln list.</summary>
     public const string TW2310 = "TW2310";
 


### PR DESCRIPTION
## What changed

Added six new diagnostic codes to `src/Typewriter.Application/Diagnostics/DiagnosticCode.cs` in the TW22xx range, reserved for Roslyn workspace load failures:

| Code | Severity | Description |
|------|----------|-------------|
| TW2200 | Error | General workspace load failure: MSBuildWorkspace emitted a diagnostic with error severity |
| TW2201 | Warning | Non-fatal workspace diagnostic during project open |
| TW2202 | Error | Compilation failure: Roslyn compilation was null or contained error-severity diagnostics |
| TW2203 | Error | Project not found in workspace after `OpenProjectAsync` |
| TW2204 | Error | Workspace project reference could not be resolved |
| TW2205 | Warning | Workspace loaded with partial documents |

## Why

Closes #125. These codes are required by M5 semantic model extraction to emit structured, CI-parseable diagnostics for all Roslyn workspace failure modes before implementing the extraction services.

## Verification

- `dotnet build -c Release` → Build succeeded, 0 errors, 0 warnings