### PR TITLE
feat: implement RoslynWorkspaceService (M5, #130)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-03 by Claude (Executor, #127, #128)
+> Last touched: 2026-03-03 by Claude (Executor, #130)
 
 ## Current State
 
 - **Active milestone**: M5 - Semantic model extraction parity
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Implement RoslynWorkspaceService in Loading.MSBuild that satisfies IRoslynWorkspaceService
+- **Next step**: Wire RoslynWorkspaceService into ApplicationRunner pipeline (M5 continuation)
 
 ## Milestone Map
 
@@ -81,6 +81,7 @@
 | #127 Add Microsoft.CodeAnalysis.Workspaces.MSBuild NuGet ref | M5 | Executor | Done | Added `Microsoft.CodeAnalysis.Workspaces.MSBuild 4.*` to `Loading.MSBuild.csproj`; added companion MSBuild 17.* ExcludeAssets="runtime" refs to all projects to suppress MSBL001; restore/build 0 errors, 136 unit tests pass |
 | #128 Create source-generator test fixture | M5 | Executor | Done | `SourceGenLib.csproj` (net10.0) + `Class1.cs`; `SourceGenerator/` (netstandard2.0, HelloWorldGenerator IIncrementalGenerator); `SourceGenFixtureTests` verifies `GetTypesByMetadataName("SourceGenLib.GeneratedHelper")` returns non-empty; IntegrationTests.csproj updated (exclusions + SourceGenerator ref); build 0 errors/warnings, test passes |
 | #129 Create IRoslynWorkspaceService interface | M5 | Executor | Done | `src/Typewriter.Application/Loading/IRoslynWorkspaceService.cs`; `LoadAsync(ProjectLoadPlan, IDiagnosticReporter, CancellationToken)` returning `Task<WorkspaceLoadResult?>`; no MSBuild types; build 0 errors/warnings |
+| #130 Implement RoslynWorkspaceService | M5 | Executor | Done | `src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs`; MSBuildWorkspace.Create from GlobalProperties; OpenProjectAsync per LoadTarget; workspace diagnostics → TW2200/TW2201; null/error compilation → TW2202; returns WorkspaceLoadResult; build 0 errors/warnings |
 
 ## Decisions
 

--- a/src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs
+++ b/src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs
@@ -1,0 +1,127 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using Typewriter.Application.Diagnostics;
+using Typewriter.Application.Loading;
+using Typewriter.Application.Orchestration;
+
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
+using TwDiagnosticSeverity = Typewriter.Application.Diagnostics.DiagnosticSeverity;
+
+namespace Typewriter.Loading.MSBuild;
+
+/// <summary>
+/// Opens each project from a <see cref="ProjectLoadPlan"/> in a Roslyn
+/// <see cref="MSBuildWorkspace"/> and returns the projects paired with their compilations.
+/// MSBuild registration must be completed by <see cref="IMsBuildLocatorService"/> before
+/// calling <see cref="LoadAsync"/>.
+/// </summary>
+public sealed class RoslynWorkspaceService : IRoslynWorkspaceService
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Creates a single <see cref="MSBuildWorkspace"/> for the entire plan, opens each
+    /// <see cref="LoadTarget"/> in topological order, and collects workspace diagnostics
+    /// emitted during each <c>OpenProjectAsync</c> call.  Compilation errors are reported
+    /// via <paramref name="reporter"/> but do not prevent the entry from appearing in the
+    /// result; a null compilation skips the entry entirely.  Returns <c>null</c> only when
+    /// the workspace itself cannot be created.
+    /// </remarks>
+    public async Task<WorkspaceLoadResult?> LoadAsync(
+        ProjectLoadPlan plan,
+        IDiagnosticReporter reporter,
+        CancellationToken ct)
+    {
+        var properties = new Dictionary<string, string>(plan.GlobalProperties);
+
+        MSBuildWorkspace workspace;
+        try
+        {
+            workspace = MSBuildWorkspace.Create(properties);
+        }
+        catch (Exception ex)
+        {
+            reporter.Report(new DiagnosticMessage(
+                TwDiagnosticSeverity.Error,
+                DiagnosticCode.TW2200,
+                $"Failed to create MSBuildWorkspace: {ex.Message}"));
+            return null;
+        }
+
+        // Workspace is intentionally not wrapped in a using block: Project objects returned
+        // in WorkspaceLoadResult hold workspace references that callers may need for further
+        // Roslyn queries.  For a single-invocation CLI process the GC reclaims the workspace
+        // on exit.
+        var entries = new List<(Project, Compilation)>();
+
+        foreach (var loadTarget in plan.Targets)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Snapshot the diagnostic count so we can identify diagnostics added by this open.
+            int diagCountBefore = workspace.Diagnostics.Count;
+
+            Project project;
+            try
+            {
+                project = await workspace.OpenProjectAsync(loadTarget.ProjectPath, cancellationToken: ct);
+            }
+            catch (Exception ex)
+            {
+                reporter.Report(new DiagnosticMessage(
+                    TwDiagnosticSeverity.Error,
+                    DiagnosticCode.TW2200,
+                    $"Failed to open project '{loadTarget.ProjectPath}': {ex.Message}",
+                    File: loadTarget.ProjectPath));
+                continue;
+            }
+
+            // Emit workspace diagnostics collected during this project open.
+            foreach (var workspaceDiag in workspace.Diagnostics.Skip(diagCountBefore))
+            {
+                var (severity, code) = workspaceDiag.Kind == WorkspaceDiagnosticKind.Failure
+                    ? (TwDiagnosticSeverity.Error, DiagnosticCode.TW2200)
+                    : (TwDiagnosticSeverity.Warning, DiagnosticCode.TW2201);
+                reporter.Report(new DiagnosticMessage(
+                    severity, code, workspaceDiag.Message, File: loadTarget.ProjectPath));
+            }
+
+            Compilation? compilation;
+            try
+            {
+                compilation = await project.GetCompilationAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                reporter.Report(new DiagnosticMessage(
+                    TwDiagnosticSeverity.Error,
+                    DiagnosticCode.TW2202,
+                    $"Compilation failed for project '{loadTarget.ProjectName}': {ex.Message}",
+                    File: loadTarget.ProjectPath));
+                continue;
+            }
+
+            if (compilation is null)
+            {
+                reporter.Report(new DiagnosticMessage(
+                    TwDiagnosticSeverity.Error,
+                    DiagnosticCode.TW2202,
+                    $"Compilation was null for project '{loadTarget.ProjectName}'.",
+                    File: loadTarget.ProjectPath));
+                continue;
+            }
+
+            if (compilation.GetDiagnostics(ct).Any(d => d.Severity == RoslynDiagnosticSeverity.Error))
+            {
+                reporter.Report(new DiagnosticMessage(
+                    TwDiagnosticSeverity.Error,
+                    DiagnosticCode.TW2202,
+                    $"Compilation for project '{loadTarget.ProjectName}' contains error diagnostics.",
+                    File: loadTarget.ProjectPath));
+            }
+
+            entries.Add((project, compilation));
+        }
+
+        return new WorkspaceLoadResult(entries);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs` implementing `IRoslynWorkspaceService`
- Creates an `MSBuildWorkspace` from `plan.GlobalProperties`, opens each `LoadTarget` via `OpenProjectAsync`, and retrieves compilations via `GetCompilationAsync`
- Workspace diagnostics emitted per project open: `TW2200` for failures, `TW2201` for warnings
- `TW2202` emitted when compilation is null or contains error-severity Roslyn diagnostics
- Returns `WorkspaceLoadResult` with all successfully compiled `(Project, Compilation)` pairs; returns `null` only on catastrophic workspace creation failure
- Does not call `MSBuildLocator` — registration is left to `MsBuildLocatorService`

## Test plan

- [x] `dotnet build -c Release` succeeds with 0 errors and 0 warnings
- [ ] Integration test coverage will be added in a follow-up task once workspace loading is wired into `ApplicationRunner`

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)