### PR TITLE
feat: compose RoslynWorkspaceService in Program.cs (M5, #133)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -7,7 +7,7 @@
 - **Active milestone**: M5 - Semantic model extraction parity
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Wire RoslynWorkspaceService into ApplicationRunner pipeline (M5 continuation)
+- **Next step**: Implement semantic metadata extraction using WorkspaceLoadResult (M5 continuation)
 
 ## Milestone Map
 
@@ -82,6 +82,7 @@
 | #128 Create source-generator test fixture | M5 | Executor | Done | `SourceGenLib.csproj` (net10.0) + `Class1.cs`; `SourceGenerator/` (netstandard2.0, HelloWorldGenerator IIncrementalGenerator); `SourceGenFixtureTests` verifies `GetTypesByMetadataName("SourceGenLib.GeneratedHelper")` returns non-empty; IntegrationTests.csproj updated (exclusions + SourceGenerator ref); build 0 errors/warnings, test passes |
 | #129 Create IRoslynWorkspaceService interface | M5 | Executor | Done | `src/Typewriter.Application/Loading/IRoslynWorkspaceService.cs`; `LoadAsync(ProjectLoadPlan, IDiagnosticReporter, CancellationToken)` returning `Task<WorkspaceLoadResult?>`; no MSBuild types; build 0 errors/warnings |
 | #130 Implement RoslynWorkspaceService | M5 | Executor | Done | `src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs`; MSBuildWorkspace.Create from GlobalProperties; OpenProjectAsync per LoadTarget; workspace diagnostics → TW2200/TW2201; null/error compilation → TW2202; returns WorkspaceLoadResult; build 0 errors/warnings |
+| #133 Compose RoslynWorkspaceService in Program.cs | M5 | Executor | Done | `Program.cs` instantiates `RoslynWorkspaceService`; passed to `ApplicationRunner` ctor; `ApplicationRunner` calls `LoadAsync` after `BuildPlanAsync` (step 6); all tests updated; 151/151 pass |
 
 ## Decisions
 

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -4,22 +4,29 @@ using Typewriter.Application.Loading;
 namespace Typewriter.Application;
 
 /// <summary>
-/// Orchestrates the generate pipeline: input resolution → restore → project graph → generation.
+/// Orchestrates the generate pipeline: input resolution → restore → project graph → workspace load → generation.
 /// </summary>
 public sealed class ApplicationRunner
 {
     private readonly IInputResolver _inputResolver;
     private readonly IRestoreService _restoreService;
     private readonly IProjectGraphService _projectGraphService;
+    private readonly IRoslynWorkspaceService _roslynWorkspaceService;
 
+    /// <param name="inputResolver">Resolves and validates the input project or solution path.</param>
+    /// <param name="restoreService">Checks and runs <c>dotnet restore</c> when needed.</param>
+    /// <param name="projectGraphService">Builds the topological <see cref="ProjectLoadPlan"/> via MSBuild ProjectGraph.</param>
+    /// <param name="roslynWorkspaceService">Opens each project in a Roslyn MSBuildWorkspace and retrieves compilations.</param>
     public ApplicationRunner(
         IInputResolver inputResolver,
         IRestoreService restoreService,
-        IProjectGraphService projectGraphService)
+        IProjectGraphService projectGraphService,
+        IRoslynWorkspaceService roslynWorkspaceService)
     {
         _inputResolver = inputResolver;
         _restoreService = restoreService;
         _projectGraphService = projectGraphService;
+        _roslynWorkspaceService = roslynWorkspaceService;
     }
 
     /// <summary>
@@ -86,7 +93,12 @@ public sealed class ApplicationRunner
         if (plan is null)
             return 3;
 
-        // 6. Elevate warnings to errors if --fail-on-warnings was specified.
+        // 6. Load the Roslyn workspace for semantic model extraction.
+        var workspaceResult = await _roslynWorkspaceService.LoadAsync(plan, reporter, cancellationToken);
+        if (workspaceResult is null)
+            return 3;
+
+        // 7. Elevate warnings to errors if --fail-on-warnings was specified.
         if (options.FailOnWarnings && reporter.WarningCount > 0)
             return 1;
 

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -61,8 +61,9 @@ generateCommand.SetHandler(async (InvocationContext ctx) =>
     var restoreService = new RestoreService();
     var solutionFallbackService = new SolutionFallbackService();
     var projectGraphService = new ProjectGraphService(locatorService, solutionFallbackService);
+    var roslynWorkspaceService = new RoslynWorkspaceService();
 
-    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService);
+    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService, roslynWorkspaceService);
     ctx.ExitCode = await runner.RunAsync(options, reporter, ctx.GetCancellationToken());
 });
 

--- a/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
+++ b/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
@@ -1,3 +1,5 @@
+using RoslynCompilation = Microsoft.CodeAnalysis.Compilation;
+using RoslynProject = Microsoft.CodeAnalysis.Project;
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
@@ -62,8 +64,23 @@ public class CliContractTests
         }
     }
 
+    /// <summary>Roslyn workspace service stub that returns an empty but non-null workspace result.</summary>
+    private sealed class StubRoslynWorkspaceService : IRoslynWorkspaceService
+    {
+        public Task<WorkspaceLoadResult?> LoadAsync(
+            ProjectLoadPlan plan,
+            IDiagnosticReporter reporter,
+            CancellationToken ct = default)
+            => Task.FromResult<WorkspaceLoadResult?>(
+                new WorkspaceLoadResult(new List<(RoslynProject, RoslynCompilation)>()));
+    }
+
     private static ApplicationRunner CreateRunner()
-        => new ApplicationRunner(new StubInputResolver(), new StubRestoreService(), new StubProjectGraphService());
+        => new ApplicationRunner(
+            new StubInputResolver(),
+            new StubRestoreService(),
+            new StubProjectGraphService(),
+            new StubRoslynWorkspaceService());
 
     [Fact]
     public async Task Generate_InvalidArgs_Returns2()

--- a/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
+++ b/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
@@ -1,3 +1,5 @@
+using RoslynCompilation = Microsoft.CodeAnalysis.Compilation;
+using RoslynProject = Microsoft.CodeAnalysis.Project;
 using NSubstitute;
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
@@ -39,6 +41,7 @@ public class ProjectLoaderTests
         var inputResolver = Substitute.For<IInputResolver>();
         var restoreService = Substitute.For<IRestoreService>();
         var graphService = Substitute.For<IProjectGraphService>();
+        var workspaceService = Substitute.For<IRoslynWorkspaceService>();
         var reporter = Substitute.For<IDiagnosticReporter>();
 
         inputResolver
@@ -59,7 +62,11 @@ public class ProjectLoaderTests
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<ProjectLoadPlan?>(ValidPlan(ProjectPath)));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService);
+        workspaceService
+            .LoadAsync(Arg.Any<ProjectLoadPlan>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult(new List<(RoslynProject, RoslynCompilation)>())));
+
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, workspaceService);
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
@@ -78,6 +85,7 @@ public class ProjectLoaderTests
         var inputResolver = Substitute.For<IInputResolver>();
         var restoreService = Substitute.For<IRestoreService>();
         var graphService = Substitute.For<IProjectGraphService>();
+        var workspaceService = Substitute.For<IRoslynWorkspaceService>();
         var reporter = Substitute.For<IDiagnosticReporter>();
 
         inputResolver
@@ -88,7 +96,7 @@ public class ProjectLoaderTests
             .CheckAssetsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService);
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, workspaceService);
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
@@ -105,6 +113,7 @@ public class ProjectLoaderTests
         var inputResolver = Substitute.For<IInputResolver>();
         var restoreService = Substitute.For<IRestoreService>();
         var graphService = Substitute.For<IProjectGraphService>();
+        var workspaceService = Substitute.For<IRoslynWorkspaceService>();
         var reporter = Substitute.For<IDiagnosticReporter>();
 
         inputResolver
@@ -129,7 +138,11 @@ public class ProjectLoaderTests
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<ProjectLoadPlan?>(ValidPlan(ProjectPath)));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService);
+        workspaceService
+            .LoadAsync(Arg.Any<ProjectLoadPlan>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult(new List<(RoslynProject, RoslynCompilation)>())));
+
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, workspaceService);
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: true), reporter);


### PR DESCRIPTION
## Summary

- Instantiates `RoslynWorkspaceService` in `Program.cs` composition root following the prescribed ordering: `MsBuildLocatorService` → `InputResolver` → `RestoreService` → `ProjectGraphService` → `RoslynWorkspaceService` → `ApplicationRunner`
- Adds `IRoslynWorkspaceService` parameter to `ApplicationRunner` constructor and calls `LoadAsync` as step 6 of `RunAsync` (after `BuildPlanAsync` returns a non-null plan)
- Returns exit code `3` when `LoadAsync` returns `null` (fatal workspace failure)
- Updates `CliContractTests` and `ProjectLoaderTests` with stubs/mocks for the new dependency; resolves `DiagnosticSeverity` ambiguity via type aliases

Closes #133

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] `dotnet test -c Release` — 151/151 tests pass (136 unit, 13 integration, 1 golden, 1 performance)
- [x] Existing `CsprojIntegrationTests` still pass
- [x] `CliContractTests` and `ProjectLoaderTests` updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)