### PR TITLE
feat: port Parser.cs and SingleFileParser.cs to Typewriter.Generation (M6, #143)

### DIFF
--- a/src/Typewriter.Generation/Parser.cs
+++ b/src/Typewriter.Generation/Parser.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Typewriter.CodeModel;
+using Type = System.Type;
+
+namespace Typewriter.Generation
+{
+    /// <summary>
+    /// Parses a Typewriter template against a single code model context and produces the rendered output.
+    /// </summary>
+    public class Parser
+    {
+        /// <summary>
+        /// Parses the given <paramref name="template"/> using the specified <paramref name="context"/> and returns the rendered output.
+        /// </summary>
+        /// <param name="templatePath">Absolute path to the template file (used for diagnostics).</param>
+        /// <param name="sourcePath">Absolute path to the source file being rendered.</param>
+        /// <param name="template">The template text to parse.</param>
+        /// <param name="extensions">Extension method types available for identifier resolution.</param>
+        /// <param name="context">The code model object to render (e.g., a <see cref="CodeModel.File"/>).</param>
+        /// <param name="success">Set to <see langword="true"/> if parsing completed without errors.</param>
+        /// <param name="errorReporter">Optional callback invoked with a diagnostic message when a parse error occurs.</param>
+        /// <returns>The rendered output, or <see langword="null"/> if no template identifiers matched the context.</returns>
+        public static string? Parse(string templatePath, string sourcePath, string template, List<Type> extensions, object context, out bool success, Action<string>? errorReporter = null)
+        {
+            var instance = new Parser(extensions, errorReporter);
+            var output = instance.ParseTemplate(templatePath, sourcePath, template, context);
+            success = !instance.hasError;
+
+            return instance.matchFound ? output : null;
+        }
+
+        private readonly List<Type> extensions;
+        private readonly Action<string>? errorReporter;
+        private bool matchFound;
+        private bool hasError;
+
+        private Parser(List<Type> extensions, Action<string>? errorReporter)
+        {
+            this.extensions = extensions;
+            this.errorReporter = errorReporter;
+        }
+
+        private string? ParseTemplate(string templatePath, string sourcePath, string? template, object context)
+        {
+            if (string.IsNullOrEmpty(template))
+            {
+                return null;
+            }
+
+            var output = new StringBuilder();
+            var stream = new Stream(template);
+
+            while (stream.Advance())
+            {
+                if (ParseDollar(templatePath, sourcePath, stream, context, output))
+                {
+                    continue;
+                }
+
+                output.Append(stream.Current);
+            }
+
+            return output.ToString();
+        }
+
+        private bool ParseDollar(string templatePath, string sourcePath, Stream stream, object context, StringBuilder output)
+        {
+            if (stream.Current == '$')
+            {
+                var identifier = stream.PeekWord(1);
+
+                if (TryGetIdentifier(templatePath, sourcePath, identifier, context, out var value))
+                {
+                    stream.Advance(identifier!.Length);
+
+                    if (value is IEnumerable<Item> collection)
+                    {
+                        var filter = ParseBlock(stream, '(', ')');
+                        var block = ParseBlock(stream, '[', ']');
+                        var separator = ParseBlock(stream, '[', ']');
+
+                        if (filter == null && block == null && separator == null)
+                        {
+                            var stringValue = value.ToString();
+
+                            if (stringValue != null && !stringValue.Equals(value.GetType().FullName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                output.Append(stringValue);
+                            }
+                            else
+                            {
+                                output.Append("$").Append(identifier);
+                            }
+                        }
+                        else
+                        {
+                            IEnumerable<Item> items;
+                            if (filter != null && filter.StartsWith("$", StringComparison.OrdinalIgnoreCase))
+                            {
+                                var predicate = filter.Remove(0, 1);
+                                if (extensions != null)
+                                {
+                                    // Lambda filters are always defined in the first extension type
+                                    var c = extensions.FirstOrDefault()?.GetMethod(predicate);
+                                    if (c != null)
+                                    {
+                                        try
+                                        {
+                                            items = collection.Where(x => (bool)c.Invoke(null, new object[] { x })!).ToList();
+                                            matchFound = matchFound || items.Any();
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            items = Array.Empty<Item>();
+                                            hasError = true;
+
+                                            var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'.";
+                                            LogException(e, message, templatePath, sourcePath);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        items = Array.Empty<Item>();
+                                    }
+                                }
+                                else
+                                {
+                                    items = Array.Empty<Item>();
+                                }
+                            }
+                            else
+                            {
+                                items = ItemFilter.Apply(collection, filter!, ref matchFound);
+                            }
+
+                            output.Append(string.Join(ParseTemplate(templatePath, sourcePath, separator, context),
+                                items.Select(item => ParseTemplate(templatePath, sourcePath, block, item))));
+                        }
+                    }
+                    else if (value is bool boolValue)
+                    {
+                        var trueBlock = ParseBlock(stream, '[', ']');
+                        var falseBlock = ParseBlock(stream, '[', ']');
+
+                        output.Append(ParseTemplate(templatePath, sourcePath, boolValue ? trueBlock : falseBlock, context));
+                    }
+                    else
+                    {
+                        var block = ParseBlock(stream, '[', ']');
+                        if (value != null)
+                        {
+                            if (block != null)
+                            {
+                                output.Append(ParseTemplate(templatePath, sourcePath, block, value));
+                            }
+                            else
+                            {
+                                output.Append(value.ToString());
+                            }
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string? ParseBlock(Stream stream, char open, char close)
+        {
+            if (stream.Peek() == open)
+            {
+                var block = stream.PeekBlock(2, open, close);
+
+                stream.Advance(block.Length);
+                stream.Advance(stream.Peek(2) == close ? 2 : 1);
+
+                return block;
+            }
+
+            return null;
+        }
+
+        private bool TryGetIdentifier(string templatePath, string sourcePath, string? identifier, object context, out object? value)
+        {
+            value = null;
+
+            if (identifier == null)
+            {
+                return false;
+            }
+
+            var type = context.GetType();
+
+            try
+            {
+                var property = type.GetProperty(identifier);
+                if (property != null)
+                {
+                    value = property.GetValue(context);
+                    return true;
+                }
+
+                var extension = extensions.Select(e => e.GetMethod(identifier, new[] { type })).FirstOrDefault(m => m != null);
+                if (extension != null)
+                {
+                    value = extension.Invoke(null, new[] { context });
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                hasError = true;
+
+                var message = $"Error rendering template. Cannot get identifier '{identifier}'.";
+                LogException(e, message, templatePath, sourcePath);
+            }
+
+            return false;
+        }
+
+        private void LogException(Exception exception, string message, string templatePath, string sourcePath)
+        {
+            // Skip the target invocation exception, get the real exception instead.
+            if (exception is TargetInvocationException && exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
+            var logMessage = $"{message} Error: {exception.Message}. Template: {templatePath}. Source path: {sourcePath}.{Environment.NewLine}{exception}";
+
+            errorReporter?.Invoke(logMessage);
+        }
+    }
+}

--- a/src/Typewriter.Generation/SingleFileParser.cs
+++ b/src/Typewriter.Generation/SingleFileParser.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Typewriter.CodeModel;
+using File = Typewriter.CodeModel.File;
+using Type = System.Type;
+
+namespace Typewriter.Generation
+{
+    /// <summary>
+    /// Parses a Typewriter template against multiple <see cref="File"/> instances,
+    /// aggregating output from all files into a single result.
+    /// </summary>
+    public class SingleFileParser
+    {
+        /// <summary>
+        /// Parses the given <paramref name="template"/> using the specified <paramref name="files"/> and returns the rendered output.
+        /// </summary>
+        /// <param name="templatePath">Absolute path to the template file (used for diagnostics).</param>
+        /// <param name="files">The code model files to render into the template.</param>
+        /// <param name="template">The template text to parse.</param>
+        /// <param name="extensions">Extension method types available for identifier resolution.</param>
+        /// <param name="success">Set to <see langword="true"/> if parsing completed without errors.</param>
+        /// <param name="errorReporter">Optional callback invoked with a diagnostic message when a parse error occurs.</param>
+        /// <returns>The rendered output, or <see langword="null"/> if no template identifiers matched the context.</returns>
+        public static string? Parse(string templatePath, File[] files, string template, List<Type> extensions, out bool success, Action<string>? errorReporter = null)
+        {
+            var instance = new SingleFileParser(extensions, errorReporter);
+            var output = instance.ParseTemplate(templatePath, template, files);
+            success = !instance.hasError;
+
+            return instance.matchFound ? output : null;
+        }
+
+        private readonly List<Type> extensions;
+        private readonly Action<string>? errorReporter;
+        private bool matchFound;
+        private bool hasError;
+
+        private SingleFileParser(List<Type> extensions, Action<string>? errorReporter)
+        {
+            this.extensions = extensions;
+            this.errorReporter = errorReporter;
+        }
+
+        private string? ParseTemplate(string templatePath, string template, File[] files, object? context = null)
+        {
+            if (string.IsNullOrEmpty(template))
+            {
+                return null;
+            }
+
+            var output = new StringBuilder();
+            var stream = new Stream(template);
+
+            while (stream.Advance())
+            {
+                if (ParseDollar(templatePath, template, files, stream, context, output))
+                {
+                    continue;
+                }
+
+                output.Append(stream.Current);
+            }
+
+            return output.ToString();
+        }
+
+        private bool ParseDollar(string templatePath, string template, File[] files, Stream stream, object? context, StringBuilder output)
+        {
+            if (stream.Current == '$')
+            {
+                var identifier = stream.PeekWord(1);
+
+                _ = stream.Advance(identifier?.Length ?? 0);
+                var advance = 0;
+                var offset = stream.Position + 1;
+                var index = 0;
+                foreach (var f in files)
+                {
+                    // Create new stream for each file
+                    var innerStream = new Stream(template);
+                    innerStream.Advance(offset);
+
+                    var sourcePath = f.FullName;
+                    context = f;
+
+                    if (TryGetIdentifier(templatePath, sourcePath, identifier, context, out var value))
+                    {
+                        if (value is IEnumerable<Item> collection)
+                        {
+                            var filter = ParseBlock(innerStream, '(', ')');
+                            var block = ParseBlock(innerStream, '[', ']');
+                            var separator = ParseBlock(innerStream, '[', ']');
+
+                            if (filter == null && block == null && separator == null)
+                            {
+                                var stringValue = value.ToString();
+
+                                if (stringValue != null && !string.Equals(stringValue, value.GetType().FullName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    output.Append(stringValue);
+                                }
+                                else
+                                {
+                                    output.Append("$").Append(identifier);
+                                }
+                            }
+                            else
+                            {
+                                var items = ApplyFilter(collection, filter, templatePath, identifier!, sourcePath);
+
+                                output.Append(string.Join(ParseTemplate(templatePath, sourcePath, separator, context),
+                                    items.Select(item => ParseTemplate(templatePath, sourcePath, block, item))));
+                                // In this case we must check if we get items of the next element too
+                                for (var i = index + 1; i < files.Length; i++)
+                                {
+                                    var next = files[i];
+
+                                    if (next != null)
+                                    {
+                                        if (TryGetIdentifier(templatePath, next.FullName, identifier, next, out var vnext))
+                                        {
+                                            if (vnext is IEnumerable<Item> colnext)
+                                            {
+                                                colnext = ApplyFilter(colnext, filter, templatePath, identifier!, next.FullName);
+
+                                                if (colnext.Any())
+                                                {
+                                                    output.Append(ParseTemplate(templatePath, sourcePath, separator, context));
+
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else if (value is bool boolValue)
+                        {
+                            var trueBlock = ParseBlock(innerStream, '[', ']');
+                            var falseBlock = ParseBlock(innerStream, '[', ']');
+
+                            output.Append(ParseTemplate(templatePath, sourcePath, boolValue ? trueBlock : falseBlock, context));
+                        }
+                        else
+                        {
+                            var block = ParseBlock(innerStream, '[', ']');
+                            if (value != null)
+                            {
+                                if (block != null)
+                                {
+                                    output.Append(ParseTemplate(templatePath, sourcePath, block, value));
+                                }
+                                else
+                                {
+                                    output.Append(value.ToString());
+                                }
+                            }
+                        }
+                    }
+
+                    advance = innerStream.Position + 1;
+                    index++;
+                }
+
+                var canAdvance = stream.Advance(advance - offset);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private IEnumerable<Item> ApplyFilter(IEnumerable<Item> collection, string? filter, string templatePath, string identifier, string sourcePath)
+        {
+            IEnumerable<Item> items;
+            if (filter != null && filter.StartsWith("$", StringComparison.OrdinalIgnoreCase))
+            {
+                var predicate = filter.Remove(0, 1);
+                if (extensions != null)
+                {
+                    // Lambda filters are always defined in the first extension type
+                    var c = extensions.FirstOrDefault()?.GetMethod(predicate);
+                    if (c != null)
+                    {
+                        try
+                        {
+                            items = collection.Where(x => (bool)c.Invoke(null, new object[] { x })!).ToList();
+                            matchFound = matchFound || items.Any();
+                        }
+                        catch (Exception e)
+                        {
+                            items = Array.Empty<Item>();
+                            hasError = true;
+
+                            var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'.";
+                            LogException(e, message, templatePath, sourcePath);
+                        }
+                    }
+                    else
+                    {
+                        items = Array.Empty<Item>();
+                    }
+                }
+                else
+                {
+                    items = Array.Empty<Item>();
+                }
+            }
+            else
+            {
+                items = ItemFilter.Apply(collection, filter!, ref matchFound);
+            }
+
+            return items;
+        }
+
+        private static string? ParseBlock(Stream stream, char open, char close, bool onlyPeek = false)
+        {
+            if (stream.Peek() == open)
+            {
+                var block = stream.PeekBlock(2, open, close);
+
+                if (!onlyPeek)
+                {
+                    stream.Advance(block.Length);
+                    stream.Advance(stream.Peek(2) == close ? 2 : 1);
+                }
+
+                return block;
+            }
+
+            return null;
+        }
+
+        private bool TryGetIdentifier(string templatePath, string sourcePath, string? identifier, object context, out object? value)
+        {
+            value = null;
+
+            if (identifier == null)
+            {
+                return false;
+            }
+
+            var type = context.GetType();
+
+            try
+            {
+                var property = type.GetProperty(identifier);
+                if (property != null)
+                {
+                    value = property.GetValue(context);
+                    return true;
+                }
+
+                var extension = extensions.Select(e => e.GetMethod(identifier, new[] { type })).FirstOrDefault(m => m != null);
+                if (extension != null)
+                {
+                    value = extension.Invoke(null, new[] { context });
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                hasError = true;
+
+                var message = $"Error rendering template. Cannot get identifier '{identifier}'.";
+                LogException(e, message, templatePath, sourcePath);
+            }
+
+            return false;
+        }
+
+        private void LogException(Exception exception, string message, string templatePath, string sourcePath)
+        {
+            // Skip the target invocation exception, get the real exception instead.
+            if (exception is TargetInvocationException && exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
+            var logMessage = $"{message} Error: {exception.Message}. Template: {templatePath}. Source path: {sourcePath}.{Environment.NewLine}{exception}";
+
+            errorReporter?.Invoke(logMessage);
+        }
+
+        private string? ParseTemplate(string templatePath, string sourcePath, string? template, object context)
+        {
+            if (string.IsNullOrEmpty(template))
+            {
+                return null;
+            }
+
+            var output = new StringBuilder();
+            var stream = new Stream(template);
+
+            while (stream.Advance())
+            {
+                if (ParseDollar(templatePath, sourcePath, stream, context, output))
+                {
+                    continue;
+                }
+
+                output.Append(stream.Current);
+            }
+
+            return output.ToString();
+        }
+
+        private bool ParseDollar(string templatePath, string sourcePath, Stream stream, object context, StringBuilder output)
+        {
+            if (stream.Current == '$')
+            {
+                var identifier = stream.PeekWord(1);
+
+                if (TryGetIdentifier(templatePath, sourcePath, identifier, context, out var value))
+                {
+                    stream.Advance(identifier!.Length);
+
+                    if (value is IEnumerable<Item> collection)
+                    {
+                        var filter = ParseBlock(stream, '(', ')');
+                        var block = ParseBlock(stream, '[', ']');
+                        var separator = ParseBlock(stream, '[', ']');
+
+                        if (filter == null && block == null && separator == null)
+                        {
+                            var stringValue = value.ToString();
+
+                            if (stringValue != null && !string.Equals(stringValue, value.GetType().FullName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                output.Append(stringValue);
+                            }
+                            else
+                            {
+                                output.Append("$").Append(identifier);
+                            }
+                        }
+                        else
+                        {
+                            IEnumerable<Item> items;
+                            if (filter != null && filter.StartsWith("$", StringComparison.OrdinalIgnoreCase))
+                            {
+                                var predicate = filter.Remove(0, 1);
+                                if (extensions != null)
+                                {
+                                    // Lambda filters are always defined in the first extension type
+                                    var c = extensions.FirstOrDefault()?.GetMethod(predicate);
+                                    if (c != null)
+                                    {
+                                        try
+                                        {
+                                            items = collection.Where(x => (bool)c.Invoke(null, new object[] { x })!).ToList();
+                                            matchFound = matchFound || items.Any();
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            items = Array.Empty<Item>();
+                                            hasError = true;
+
+                                            var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'.";
+                                            LogException(e, message, templatePath, sourcePath);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        items = Array.Empty<Item>();
+                                    }
+                                }
+                                else
+                                {
+                                    items = Array.Empty<Item>();
+                                }
+                            }
+                            else
+                            {
+                                items = ItemFilter.Apply(collection, filter!, ref matchFound);
+                            }
+
+                            output.Append(string.Join(ParseTemplate(templatePath, sourcePath, separator, context),
+                                items.Select(item => ParseTemplate(templatePath, sourcePath, block, item))));
+                        }
+                    }
+                    else if (value is bool boolValue)
+                    {
+                        var trueBlock = ParseBlock(stream, '[', ']');
+                        var falseBlock = ParseBlock(stream, '[', ']');
+
+                        output.Append(ParseTemplate(templatePath, sourcePath, boolValue ? trueBlock : falseBlock, context));
+                    }
+                    else
+                    {
+                        var block = ParseBlock(stream, '[', ']');
+                        if (value != null)
+                        {
+                            if (block != null)
+                            {
+                                output.Append(ParseTemplate(templatePath, sourcePath, block, value));
+                            }
+                            else
+                            {
+                                output.Append(value.ToString());
+                            }
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Typewriter.Generation/Stream.cs
+++ b/src/Typewriter.Generation/Stream.cs
@@ -1,0 +1,219 @@
+using System.Text;
+
+namespace Typewriter.Generation
+{
+    /// <summary>
+    /// Character stream for template parsing. Provides lookahead and block-extraction
+    /// capabilities used by <see cref="Parser"/> and <see cref="SingleFileParser"/>.
+    /// </summary>
+    internal class Stream
+    {
+        private readonly int offset;
+        private readonly string template;
+        private int position = -1;
+        private char current = char.MinValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Stream"/> class.
+        /// </summary>
+        /// <param name="template">The template string to stream over.</param>
+        /// <param name="offset">An offset applied to the reported <see cref="Position"/>.</param>
+        public Stream(string template, int offset = 0)
+        {
+            this.offset = offset;
+            this.template = template ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the current logical position (including the initial offset).
+        /// </summary>
+        public int Position
+        {
+            get { return position + offset; }
+        }
+
+        /// <summary>
+        /// Gets the character at the current position.
+        /// </summary>
+        public char Current
+        {
+            get { return current; }
+        }
+
+        /// <summary>
+        /// Advances the stream by <paramref name="offset"/> characters.
+        /// </summary>
+        /// <param name="offset">Number of characters to advance.</param>
+        /// <returns><see langword="true"/> if the stream has not reached the end; otherwise <see langword="false"/>.</returns>
+        public bool Advance(int offset = 1)
+        {
+            for (var i = 0; i < offset; i++)
+            {
+                position++;
+
+                if (position >= template.Length)
+                {
+                    current = char.MinValue;
+                    return false;
+                }
+
+                current = template[position];
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Peeks at the character at the given <paramref name="offset"/> relative to the current position.
+        /// </summary>
+        /// <param name="offset">Offset from the current position.</param>
+        /// <returns>The character at the offset, or <see cref="char.MinValue"/> if out of range.</returns>
+        public char Peek(int offset = 1)
+        {
+            var index = position + offset;
+
+            if (index > -1 && index < template.Length)
+            {
+                return template[index];
+            }
+
+            return char.MinValue;
+        }
+
+        /// <summary>
+        /// Peeks at the next word (identifier) starting at <paramref name="start"/> offset from the current position.
+        /// </summary>
+        /// <param name="start">Offset from the current position to begin reading.</param>
+        /// <returns>The word string, or <see langword="null"/> if no letter is found at the start.</returns>
+        public string? PeekWord(int start = 0)
+        {
+            if (!char.IsLetter(Peek(start)))
+            {
+                return null;
+            }
+
+            var identifier = new StringBuilder();
+            var i = start;
+            while (char.IsLetterOrDigit(Peek(i)))
+            {
+                identifier.Append(Peek(i));
+                i++;
+            }
+
+            return identifier.ToString();
+        }
+
+        /// <summary>
+        /// Peeks at the next line starting at <paramref name="start"/> offset from the current position.
+        /// </summary>
+        /// <param name="start">Offset from the current position to begin reading.</param>
+        /// <returns>The line content including the trailing newline.</returns>
+        public string PeekLine(int start = 0)
+        {
+            var line = new StringBuilder();
+            var i = start;
+            do
+            {
+                line.Append(Peek(i));
+                i++;
+            } while (Peek(i) != '\n' && i + position < template.Length);
+
+            line.Append('\n');
+
+            return line.ToString();
+        }
+
+        /// <summary>
+        /// Peeks at a balanced block delimited by <paramref name="open"/> and <paramref name="close"/> characters.
+        /// </summary>
+        /// <param name="start">Offset from the current position to begin reading.</param>
+        /// <param name="open">The opening delimiter character.</param>
+        /// <param name="close">The closing delimiter character.</param>
+        /// <returns>The content between the delimiters (excluding the delimiters themselves).</returns>
+        public string PeekBlock(int start, char open, char close)
+        {
+            var i = start;
+            var depth = 1;
+            var identifier = new StringBuilder();
+
+            while (depth > 0)
+            {
+                var letter = Peek(i);
+
+                if (letter == char.MinValue)
+                {
+                    break;
+                }
+
+                if (IsMatch(i, letter, close))
+                {
+                    depth--;
+                }
+
+                if (depth > 0)
+                {
+                    identifier.Append(letter);
+                    if (IsMatch(i, letter, open))
+                    {
+                        depth++;
+                    }
+
+                    i++;
+
+                    if (letter != open && (letter == '"' || letter == '\''))
+                    {
+                        var block = PeekBlock(i, letter, letter);
+                        identifier.Append(block);
+                        i += block.Length;
+
+                        if (letter == Peek(i))
+                        {
+                            identifier.Append(letter);
+                            i++;
+                        }
+                    }
+                }
+            }
+
+            return identifier.ToString();
+        }
+
+        /// <summary>
+        /// Advances past whitespace starting from the current position.
+        /// </summary>
+        /// <returns><see langword="true"/> if the stream has not reached the end; otherwise <see langword="false"/>.</returns>
+        public bool SkipWhitespace()
+        {
+            if (position < 0)
+            {
+                Advance();
+            }
+
+            while (char.IsWhiteSpace(Current))
+            {
+                Advance();
+            }
+
+            return position < template.Length;
+        }
+
+        private bool IsMatch(int index, char letter, char match)
+        {
+            if (letter == match)
+            {
+                var isString = match == '"' || match == '\'';
+                if (isString)
+                {
+                    if (Peek(index - 1) == '\\' && Peek(index - 2) != '\\')
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ported `Parser.cs` and `SingleFileParser.cs` from upstream `origin/src/Typewriter/Generation/` to `src/Typewriter.Generation/`, removing all VS-specific dependencies
- Replaced `EnvDTE.ProjectItem` parameters with `string templatePath` throughout both parser call chains
- Replaced `Log.Error` + `ErrorList.AddError/Show` with an optional `Action<string>? errorReporter` callback
- Ported `Stream.cs` (template character stream/lexer) as an internal class in `Typewriter.Generation` — required by both parsers
- Added proper nullable reference type annotations for .NET 10
- All parsing logic is functionally unchanged from upstream

Closes #143

## Test plan
- [x] `dotnet build -c Release` succeeds with zero warnings and zero errors
- [x] `dotnet test -c Release` passes all 157 tests
- [x] Zero VS-specific `using` directives (`EnvDTE`, `Microsoft.VisualStudio.*`, `Typewriter.VisualStudio`) in both files
- [x] Parsing logic diff-reviewed against upstream to confirm functional parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)