### PR TITLE
feat: adapt Compiler.cs with TemplateAssemblyLoadContext (M6, #144)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -94,6 +94,7 @@
 | #140 Port ItemFilter.cs | M6 | Executor | Done | Direct lift from upstream — zero VS coupling; `namespace Typewriter.Generation`; Placeholder.cs removed; build 0 errors/warnings, 157/157 tests pass |
 | #141 Implement TemplateAssemblyLoadContext | M6 | Executor | Done | `TemplateAssemblyLoadContext.cs` — collectible `AssemblyLoadContext` subclass; probes assemblyDir → AppContext.BaseDirectory → null fallback; TW3002 added for assembly load failures |
 | #142 Adapt TemplateCodeParser.cs | M6 | Executor | Done | `TemplateCodeParser.cs` adapted: `ProjectItem`→`string templateFilePath`, `PathResolver.ResolveRelative`→inline `ResolveReferencePath`, `Log.Error` removed; `#reference` parsing intact; stubs for `ShadowClass`, `Compiler`, `Contexts`; `Stream`+`Snippet` ported as-is to `Lexing/`; build 0 errors/0 warnings, 157/157 tests pass |
+| #144 Adapt Compiler.cs with TemplateAssemblyLoadContext | M6 | Executor | Done | `Compiler.cs` adapted: `Assembly.LoadFrom`→`TemplateAssemblyLoadContext`, `ProjectItem`→`string templateFilePath`, `ErrorList`/`Log` (VS) removed; `ShadowClass` upgraded from stub: `Clear`/`Parse`/`AddBlock`/`AddLambda`/`AddReference` now assemble source code, `Compile()` uses `CSharpCompilation` directly; build 0 errors/0 warnings, 157/157 tests pass |
 
 ## Decisions
 

--- a/src/Typewriter.Generation/Compiler.cs
+++ b/src/Typewriter.Generation/Compiler.cs
@@ -1,21 +1,113 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
 namespace Typewriter.Generation;
 
 /// <summary>
-/// Compiles template code from a shadow class into a loadable assembly type.
-/// This is a compilation stub; the full implementation with <c>AssemblyLoadContext</c>
-/// and diagnostic reporting will be provided when Compiler.cs is ported.
+/// Compiles template code from a <see cref="ShadowClass"/> into a loadable assembly type.
+/// Adapted from upstream <c>Typewriter.Generation.Compiler</c> with VS coupling removed:
+/// <list type="bullet">
+///   <item><c>EnvDTE.ProjectItem</c> replaced with <c>string templateFilePath</c>.</item>
+///   <item><c>Assembly.LoadFrom</c> replaced with <see cref="TemplateAssemblyLoadContext"/>.</item>
+///   <item><c>ErrorList</c> / <c>Log</c> (VS OutputWindow) removed; diagnostics are surfaced
+///         via the exception message on compilation failure.</item>
+/// </list>
+/// Roslyn <see cref="Microsoft.CodeAnalysis.CSharp.CSharpCompilation"/> logic is preserved
+/// in <see cref="ShadowClass.Compile(string)"/>.
 /// </summary>
 internal static class Compiler
 {
+    private static readonly string TempDirectory = Path.Combine(Path.GetTempPath(), "Typewriter");
+
     /// <summary>
-    /// Compiles the shadow class and returns the generated template type.
+    /// Compiles the shadow class and returns the generated <c>__Typewriter.Template</c> type,
+    /// loaded in an isolated <see cref="TemplateAssemblyLoadContext"/>.
     /// </summary>
-    /// <param name="templateFilePath">Absolute path to the .tst template file.</param>
+    /// <param name="templateFilePath">Absolute path to the <c>.tst</c> template file.</param>
     /// <param name="shadowClass">The shadow class containing parsed template code.</param>
     /// <returns>The compiled template <see cref="Type"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when compilation produces errors.</exception>
     public static Type Compile(string templateFilePath, ShadowClass shadowClass)
     {
-        throw new NotImplementedException(
-            "Compiler.Compile is not yet implemented. Port Compiler.cs to complete template compilation.");
+        if (!Directory.Exists(TempDirectory))
+        {
+            Directory.CreateDirectory(TempDirectory);
+        }
+
+        // Copy referenced assemblies to the temp directory so the isolated load context
+        // can resolve them at runtime.
+        foreach (var assembly in shadowClass.ReferencedAssemblies)
+        {
+            var asmSourcePath = assembly.Location;
+            if (string.IsNullOrEmpty(asmSourcePath))
+            {
+                continue;
+            }
+
+            var asmDestPath = Path.Combine(TempDirectory, Path.GetFileName(asmSourcePath));
+
+            var sourceAssemblyName = AssemblyName.GetAssemblyName(asmSourcePath);
+
+            // Skip the copy if the destination already has the same version.
+            if (File.Exists(asmDestPath))
+            {
+                var destAssemblyName = AssemblyName.GetAssemblyName(asmDestPath);
+                if (sourceAssemblyName.Version is not null
+                    && destAssemblyName.Version is not null
+                    && sourceAssemblyName.Version.CompareTo(destAssemblyName.Version) == 0)
+                {
+                    continue;
+                }
+            }
+
+            try
+            {
+                File.Copy(asmSourcePath, asmDestPath, overwrite: true);
+            }
+            catch (IOException)
+            {
+                // File may be in use by another template compilation; non-fatal.
+            }
+        }
+
+        var fileName = Path.GetRandomFileName();
+        var path = Path.Combine(TempDirectory, fileName);
+
+        var result = shadowClass.Compile(path);
+
+        var errors = result.Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error
+                     || d.Severity == DiagnosticSeverity.Warning);
+
+        var hasErrors = false;
+        var errorMessages = new List<string>();
+
+        foreach (var diagnostic in errors)
+        {
+            var message = diagnostic.GetMessage();
+            message = message.Replace("__Typewriter.", string.Empty);
+            message = message.Replace("publicstatic", string.Empty);
+
+            if (diagnostic.Severity == DiagnosticSeverity.Error || diagnostic.IsWarningAsError)
+            {
+                hasErrors = true;
+                errorMessages.Add($"error {diagnostic.Id}: {message}");
+            }
+        }
+
+        if (result.Success && !hasErrors)
+        {
+            var assemblyDir = Path.GetDirectoryName(path)!;
+            var loadContext = new TemplateAssemblyLoadContext(assemblyDir);
+            var assembly = loadContext.LoadFromAssemblyPath(path);
+            var type = assembly.GetType("__Typewriter.Template");
+
+            return type ?? throw new InvalidOperationException(
+                $"Compiled assembly does not contain the expected type '__Typewriter.Template'. Template: {templateFilePath}");
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to compile template '{templateFilePath}'. Errors:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, errorMessages));
     }
 }

--- a/src/Typewriter.Generation/ShadowClass.cs
+++ b/src/Typewriter.Generation/ShadowClass.cs
@@ -1,17 +1,61 @@
 using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Emit;
+using Typewriter.CodeModel;
 using Typewriter.Generation.Lexing;
+using File = System.IO.File;
 
 namespace Typewriter.Generation;
 
 /// <summary>
-/// Manages a shadow Roslyn compilation workspace for template code.
-/// This is a compilation stub; the full implementation will be provided
-/// when ShadowClass is ported from upstream.
+/// Manages a shadow Roslyn compilation unit for template code.
+/// Collects snippets (usings, code blocks, lambdas) and assembles them into a compilable
+/// <c>__Typewriter.Template</c> class that can be emitted to an assembly via
+/// <see cref="Compile(string)"/>.
+/// Adapted from upstream <c>Typewriter.TemplateEditor.Lexing.Roslyn.ShadowClass</c> with
+/// the VS-coupled <c>ShadowWorkspace</c> replaced by direct <see cref="CSharpCompilation"/>.
 /// </summary>
 public class ShadowClass
 {
+    private const string StartTemplate = """
+        namespace __Typewriter
+        {
+            using System;
+            using System.Linq;
+            using System.Collections.Generic;
+            using Typewriter.CodeModel;
+            using Typewriter.Configuration;
+            using Attribute = Typewriter.CodeModel.Attribute;
+            using Enum = Typewriter.CodeModel.Enum;
+            using Type = Typewriter.CodeModel.Type;
+
+        """;
+
+    private const string ClassTemplate = """
+
+            public class Template
+            {
+
+        """;
+
+    private const string EndClassTemplate = """
+
+            }
+        """;
+
+    private const string EndTemplate = """
+
+        }
+
+        """;
+
     private readonly List<Snippet> _snippets = [];
     private readonly HashSet<Assembly> _referencedAssemblies = [];
+    private int _offset;
+    private bool _classAdded;
 
     /// <summary>Gets the collected code snippets.</summary>
     public IEnumerable<Snippet> Snippets => _snippets;
@@ -19,16 +63,30 @@ public class ShadowClass
     /// <summary>Gets the referenced assemblies.</summary>
     public IEnumerable<Assembly> ReferencedAssemblies => _referencedAssemblies;
 
-    /// <summary>Clears all snippets and resets referenced assemblies.</summary>
+    /// <summary>Clears all snippets, resets referenced assemblies, and prepares for a new template.</summary>
     public void Clear()
     {
         _snippets.Clear();
+        _snippets.Add(Snippet.Create(SnippetType.Class, StartTemplate));
+        _offset = StartTemplate.Length;
+        _classAdded = false;
+
         _referencedAssemblies.Clear();
+        _referencedAssemblies.Add(typeof(Class).Assembly);
     }
 
-    /// <summary>Finalizes the shadow class for compilation.</summary>
+    /// <summary>Finalizes the shadow class by closing the class and namespace declarations.</summary>
     public void Parse()
     {
+        if (!_classAdded)
+        {
+            _snippets.Add(Snippet.Create(SnippetType.Class, ClassTemplate));
+            _offset += ClassTemplate.Length;
+            _classAdded = true;
+        }
+
+        _snippets.Add(Snippet.Create(SnippetType.Class, EndClassTemplate));
+        _snippets.Add(Snippet.Create(SnippetType.Class, EndTemplate));
     }
 
     /// <summary>
@@ -38,7 +96,8 @@ public class ShadowClass
     /// <param name="startIndex">Start index in the template.</param>
     public void AddUsing(string code, int startIndex)
     {
-        _snippets.Add(Snippet.Create(SnippetType.Using, code, 0, startIndex, startIndex + code.Length));
+        _snippets.Add(Snippet.Create(SnippetType.Using, code, _offset, startIndex, startIndex + code.Length));
+        _offset += code.Length;
     }
 
     /// <summary>
@@ -48,7 +107,15 @@ public class ShadowClass
     /// <param name="startIndex">Start index in the template.</param>
     public void AddBlock(string code, int startIndex)
     {
-        _snippets.Add(Snippet.Create(SnippetType.Code, code, 0, startIndex, startIndex + code.Length));
+        if (!_classAdded)
+        {
+            _snippets.Add(Snippet.Create(SnippetType.Class, ClassTemplate));
+            _offset += ClassTemplate.Length;
+            _classAdded = true;
+        }
+
+        _snippets.Add(Snippet.Create(SnippetType.Code, code, _offset, startIndex, startIndex + code.Length));
+        _offset += code.Length;
     }
 
     /// <summary>
@@ -57,17 +124,125 @@ public class ShadowClass
     /// <param name="pathOrName">DLL file path or assembly name.</param>
     public void AddReference(string pathOrName)
     {
+        var asm = pathOrName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            ? Assembly.LoadFile(pathOrName)
+            : Assembly.Load(pathOrName);
+
+        _referencedAssemblies.Add(asm);
     }
 
     /// <summary>
-    /// Adds a lambda expression snippet.
+    /// Adds a lambda expression snippet with a generated filter method wrapper.
     /// </summary>
-    /// <param name="code">The lambda code.</param>
+    /// <param name="code">The lambda code (e.g. <c>c =&gt; c.Name == "Foo"</c>).</param>
     /// <param name="type">The full type name of the lambda parameter.</param>
     /// <param name="name">The parameter name.</param>
-    /// <param name="startIndex">Start index in the template.</param>
+    /// <param name="startIndex">Unique method index for the generated wrapper.</param>
     public void AddLambda(string code, string type, string name, int startIndex)
     {
-        _snippets.Add(Snippet.Create(SnippetType.Lambda, code, 0, startIndex, startIndex + code.Length));
+        if (!_classAdded)
+        {
+            _snippets.Add(Snippet.Create(SnippetType.Class, ClassTemplate));
+            _offset += ClassTemplate.Length;
+            _classAdded = true;
+        }
+
+        var method = $"bool __{startIndex} ({type} {name}) {{ return ";
+        var index = code.IndexOf("=>", StringComparison.Ordinal) + 2;
+        code = code.Remove(0, index);
+
+        _snippets.Add(Snippet.Create(SnippetType.Class, method));
+        _offset += method.Length;
+
+        _snippets.Add(Snippet.Create(SnippetType.Lambda, code, _offset, startIndex, startIndex + code.Length, index));
+        _offset += code.Length;
+
+        _snippets.Add(Snippet.Create(SnippetType.Class, ";}"));
+        _offset += 2;
+    }
+
+    /// <summary>
+    /// Compiles the assembled template code into an assembly at the specified output path.
+    /// Uses <see cref="CSharpCompilation"/> directly, replacing the upstream VS-coupled
+    /// <c>ShadowWorkspace</c>.
+    /// </summary>
+    /// <param name="outputPath">Absolute path for the emitted assembly DLL.</param>
+    /// <returns>The <see cref="EmitResult"/> from the Roslyn emit operation.</returns>
+    public EmitResult Compile(string outputPath)
+    {
+        var sourceCode = string.Join(string.Empty, _snippets.Select(s => s.Code));
+        var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+
+        // Rewrite all methods and constructors to public static, matching upstream behavior.
+        var root = syntaxTree.GetCompilationUnitRoot();
+        root = MakeAllMethodsPublicStatic(root);
+        syntaxTree = root.SyntaxTree;
+
+        var metadataReferences = _referencedAssemblies
+            .Where(a => !string.IsNullOrEmpty(a.Location))
+            .Select(a => MetadataReference.CreateFromFile(a.Location))
+            .Cast<MetadataReference>()
+            .ToList();
+
+        // Add core runtime references that the upstream ShadowWorkspace included by default.
+        AddCoreReferenceIfMissing(metadataReferences, typeof(object));     // System.Runtime
+        AddCoreReferenceIfMissing(metadataReferences, typeof(Uri));        // System
+        AddCoreReferenceIfMissing(metadataReferences, typeof(Enumerable)); // System.Linq
+        AddCoreReferenceIfMissing(metadataReferences, typeof(Console));    // System.Console
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: Path.GetFileNameWithoutExtension(outputPath),
+            syntaxTrees: [syntaxTree],
+            references: metadataReferences,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var fileStream = File.Create(outputPath);
+        return compilation.Emit(fileStream);
+    }
+
+    private static void AddCoreReferenceIfMissing(List<MetadataReference> references, System.Type type)
+    {
+        var location = type.Assembly.Location;
+        if (string.IsNullOrEmpty(location))
+        {
+            return;
+        }
+
+        if (references.Any(r => string.Equals(r.Display, location, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        references.Add(MetadataReference.CreateFromFile(location));
+    }
+
+    private static CompilationUnitSyntax MakeAllMethodsPublicStatic(CompilationUnitSyntax root)
+    {
+        // Rewrite constructors to public.
+        var constructors = root.DescendantNodes().OfType<ConstructorDeclarationSyntax>().ToArray();
+        foreach (var ctor in constructors)
+        {
+            var currentCtor = root.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+                .First(c => c.Span == ctor.Span);
+            var trivia = currentCtor.GetTrailingTrivia();
+            var modifiers = SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PublicKeyword).WithTrailingTrivia(trivia));
+            root = root.ReplaceNode(currentCtor, currentCtor.WithModifiers(modifiers));
+        }
+
+        // Rewrite methods to public static.
+        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>().ToArray();
+        foreach (var method in methods)
+        {
+            var currentMethod = root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+                .First(m => m.Span == method.Span);
+            var trivia = currentMethod.ReturnType.GetTrailingTrivia();
+            var modifiers = SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PublicKeyword).WithTrailingTrivia(trivia),
+                SyntaxFactory.Token(SyntaxKind.StaticKeyword).WithTrailingTrivia(trivia));
+            root = root.ReplaceNode(currentMethod, currentMethod.WithModifiers(modifiers));
+        }
+
+        return root;
     }
 }


### PR DESCRIPTION
## Summary
- Adapts `Compiler.cs` from upstream, replacing `Assembly.LoadFrom` with `TemplateAssemblyLoadContext` for isolated template assembly loading
- Removes VS API calls (`ErrorList`, `Log`, `EnvDTE.ProjectItem`); compilation errors surfaced via `InvalidOperationException`
- Upgrades `ShadowClass` from stub to functional: assembles template source from snippets, compiles with `CSharpCompilation` directly (replacing upstream VS-coupled `ShadowWorkspace`), and rewrites methods to `public static` via AST transformation

Closes #144

## Test plan
- [x] `dotnet build -c Release` succeeds with 0 errors, 0 warnings
- [x] `dotnet test -c Release` passes all 157 tests
- [x] `Assembly.LoadFrom` is absent from code (only in doc comment)
- [x] `TemplateAssemblyLoadContext` is used for loading compiled template assembly
- [x] Roslyn `CSharpCompilation` logic preserved in `ShadowClass.Compile()`
- [x] No VS API references (`EnvDTE`, `ErrorList`, `Log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)