### PR TITLE
chore: confirm Placeholder.cs deletion from Typewriter.Generation (M6, #146)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -98,6 +98,7 @@
 | #144 Adapt Compiler.cs with TemplateAssemblyLoadContext | M6 | Executor | Done | `Compiler.cs` adapted: `Assembly.LoadFrom`→`TemplateAssemblyLoadContext`, `ProjectItem`→`string templateFilePath`, `ErrorList`/`Log` (VS) removed; `ShadowClass` upgraded from stub: `Clear`/`Parse`/`AddBlock`/`AddLambda`/`AddReference` now assemble source code, `Compile()` uses `CSharpCompilation` directly; build 0 errors/0 warnings, 157/157 tests pass |
 | #145 Adapt Template.cs removing DTE project mutation | M6 | Executor | Done | `Template.cs` adapted: `ProjectItem`→string paths, all DTE/VS calls removed (project mutation, source control, registry), output writing delegated to `IOutputWriter`, collision avoidance delegated to `IOutputPathPolicy`, single-file and multi-file modes preserved; build 0 errors/0 warnings, 160/160 tests pass |
 | #149 Add Linux/macOS TemplateAssemblyLoadContext resolver tests | M6 | Executor | Done | `AssemblyLoadContextTests.cs` — 7 tests: constructor validation, assemblyDir probe, BaseDirectory fallback, null fallback (3 Linux/macOS-specific + 4 cross-platform); build 0 errors/0 warnings, 164/164 tests pass |
+| #146 Delete Placeholder.cs from Typewriter.Generation | M6 | Executor | Done | Already removed in #140 (commit 191b407); verified no references remain; build 0 errors/0 warnings, 167/167 tests pass |
 
 ## Decisions
 


### PR DESCRIPTION
## Summary
- `src/Typewriter.Generation/Placeholder.cs` was already deleted in #140 (commit 191b407, ItemFilter.cs port)
- Verified no remaining references to the placeholder type anywhere in the codebase
- `dotnet build -c Release` succeeds with 0 errors/0 warnings
- `dotnet test -c Release` passes all 167 tests

## Acceptance criteria
- [x] `Placeholder.cs` no longer exists in `src/Typewriter.Generation/`
- [x] `dotnet build -c Release` succeeds

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)