### PR TITLE
feat: wire template execution into ApplicationRunner (M6, #150)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-04 by Claude (Executor, #145)
+> Last touched: 2026-03-04 by Claude (Executor, #150)
 
 ## Current State
 
 - **Active milestone**: M6 - Template execution and output management
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Port remaining Generation/ files (Parser.cs, SingleFileParser.cs, TemplateCodeParser.cs, Compiler.cs, Template.cs)
+- **Next step**: Complete remaining M6 tasks (golden parity, integration tests)
 
 ## Milestone Map
 
@@ -99,6 +99,8 @@
 | #145 Adapt Template.cs removing DTE project mutation | M6 | Executor | Done | `Template.cs` adapted: `ProjectItem`→string paths, all DTE/VS calls removed (project mutation, source control, registry), output writing delegated to `IOutputWriter`, collision avoidance delegated to `IOutputPathPolicy`, single-file and multi-file modes preserved; build 0 errors/0 warnings, 160/160 tests pass |
 | #149 Add Linux/macOS TemplateAssemblyLoadContext resolver tests | M6 | Executor | Done | `AssemblyLoadContextTests.cs` — 7 tests: constructor validation, assemblyDir probe, BaseDirectory fallback, null fallback (3 Linux/macOS-specific + 4 cross-platform); build 0 errors/0 warnings, 164/164 tests pass |
 | #146 Delete Placeholder.cs from Typewriter.Generation | M6 | Executor | Done | Already removed in #140 (commit 191b407); verified no references remain; build 0 errors/0 warnings, 167/167 tests pass |
+| #148 Add OutputPolicyTests unit tests | M6 | Executor | Done | OutputPolicyTests verified collision suffixes, .d.ts handling, directory preservation; build 0 errors/0 warnings |
+| #150 Wire template execution into ApplicationRunner | M6 | Executor | Done | `ApplicationRunner` gains `IOutputWriter` + `IOutputPathPolicy` deps; template execution loop after workspace load: validates .tst files, creates `RoslynMetadataProvider`, iterates `IFileMetadata`, handles single-file vs per-file mode, TW3001/TW3002 errors; all callers updated; build 0 errors/0 warnings, 169/169 tests pass |
 
 ## Decisions
 

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -1,5 +1,10 @@
 using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
+using Typewriter.CodeModel.Configuration;
+using Typewriter.CodeModel.Implementation;
+using Typewriter.Generation;
+using Typewriter.Generation.Output;
+using Typewriter.Metadata.Roslyn;
 
 namespace Typewriter.Application;
 
@@ -12,24 +17,32 @@ public sealed class ApplicationRunner
     private readonly IRestoreService _restoreService;
     private readonly IProjectGraphService _projectGraphService;
     private readonly IRoslynWorkspaceService _roslynWorkspaceService;
+    private readonly IOutputWriter _outputWriter;
+    private readonly IOutputPathPolicy _outputPathPolicy;
 
     /// <summary>
-    /// Initializes a new <see cref="ApplicationRunner"/> with the required loading services.
+    /// Initializes a new <see cref="ApplicationRunner"/> with the required loading and generation services.
     /// </summary>
     /// <param name="inputResolver">Resolves and validates the input project or solution path.</param>
     /// <param name="restoreService">Checks and performs NuGet restore when needed.</param>
     /// <param name="projectGraphService">Builds the topological load plan from MSBuild project graph.</param>
     /// <param name="roslynWorkspaceService">Opens projects in a Roslyn workspace and returns compilations.</param>
+    /// <param name="outputWriter">Writer for persisting generated output to disk.</param>
+    /// <param name="outputPathPolicy">Policy for resolving output paths with collision avoidance.</param>
     public ApplicationRunner(
         IInputResolver inputResolver,
         IRestoreService restoreService,
         IProjectGraphService projectGraphService,
-        IRoslynWorkspaceService roslynWorkspaceService)
+        IRoslynWorkspaceService roslynWorkspaceService,
+        IOutputWriter outputWriter,
+        IOutputPathPolicy outputPathPolicy)
     {
         _inputResolver = inputResolver;
         _restoreService = restoreService;
         _projectGraphService = projectGraphService;
         _roslynWorkspaceService = roslynWorkspaceService;
+        _outputWriter = outputWriter;
+        _outputPathPolicy = outputPathPolicy;
     }
 
     /// <summary>
@@ -107,10 +120,88 @@ public sealed class ApplicationRunner
             return 3;
         }
 
-        // workspaceResult is stored for use by the template execution step (M6).
-        _ = workspaceResult;
+        // 7. Validate that all template files exist before execution.
+        foreach (var templatePath in options.Templates)
+        {
+            if (!File.Exists(templatePath))
+            {
+                reporter.Report(new DiagnosticMessage(
+                    DiagnosticSeverity.Error,
+                    DiagnosticCode.TW3001,
+                    $"Template file not found: '{templatePath}'."));
+                return 1;
+            }
+        }
 
-        // 7. Elevate warnings to errors if --fail-on-warnings was specified.
+        // 8. Execute templates against loaded metadata.
+        var metadataProvider = new RoslynMetadataProvider(workspaceResult);
+        var solutionFullName = resolvedInput.SolutionDirectory ?? resolvedInput.ProjectPath;
+        var hasGenerationErrors = false;
+
+        foreach (var templatePath in options.Templates)
+        {
+            try
+            {
+                // Pre-check: enumerate source files with a lightweight settings instance.
+                // GetFiles yields all .cs documents regardless of Settings, so this is safe.
+                // Avoids triggering template compilation when the workspace has no source files.
+                var probeSettings = new SettingsImpl(templatePath, solutionFullName);
+                var sourceFiles = metadataProvider.GetFiles(probeSettings, null).ToList();
+
+                if (sourceFiles.Count == 0)
+                    continue;
+
+                var template = new Template(
+                    templatePath,
+                    solutionFullName,
+                    _outputPathPolicy,
+                    _outputWriter,
+                    error =>
+                    {
+                        reporter.Report(new DiagnosticMessage(
+                            DiagnosticSeverity.Error,
+                            DiagnosticCode.TW3001,
+                            error));
+                        hasGenerationErrors = true;
+                    });
+
+                if (template.Settings.IsSingleFileMode)
+                {
+                    var files = sourceFiles
+                        .Select(m => new FileImpl(m, template.Settings))
+                        .ToArray();
+
+                    if (!template.RenderFile(files))
+                        hasGenerationErrors = true;
+                }
+                else
+                {
+                    foreach (var fileMetadata in sourceFiles)
+                    {
+                        var file = new FileImpl(fileMetadata, template.Settings);
+
+                        if (!template.RenderFile(file))
+                            hasGenerationErrors = true;
+
+                        if (template.HasCompileException)
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                reporter.Report(new DiagnosticMessage(
+                    DiagnosticSeverity.Error,
+                    DiagnosticCode.TW3002,
+                    $"Template execution failed for '{templatePath}': {ex.Message}"));
+                hasGenerationErrors = true;
+            }
+        }
+
+        if (hasGenerationErrors)
+            return 1;
+
+        // 9. Elevate warnings to errors if --fail-on-warnings was specified.
         if (options.FailOnWarnings && reporter.WarningCount > 0)
             return 1;
 

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -4,6 +4,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
+using Typewriter.Generation.Output;
 using Typewriter.Loading.MSBuild;
 
 var rootCommand = new RootCommand("typewriter-cli \u2014 standalone Typewriter code generator");
@@ -63,7 +64,9 @@ generateCommand.SetHandler(async (InvocationContext ctx) =>
     var projectGraphService = new ProjectGraphService(locatorService, solutionFallbackService);
     var roslynWorkspaceService = new RoslynWorkspaceService();
 
-    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService, roslynWorkspaceService);
+    var outputWriter = new OutputWriter();
+    var outputPathPolicy = new OutputPathPolicy();
+    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService, roslynWorkspaceService, outputWriter, outputPathPolicy);
     ctx.ExitCode = await runner.RunAsync(options, reporter, ctx.GetCancellationToken());
 });
 

--- a/src/Typewriter.Cli/Typewriter.Cli.csproj
+++ b/src/Typewriter.Cli/Typewriter.Cli.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Typewriter.Application\Typewriter.Application.csproj" />
+    <ProjectReference Include="..\Typewriter.Generation\Typewriter.Generation.csproj" />
     <ProjectReference Include="..\Typewriter.Loading.MSBuild\Typewriter.Loading.MSBuild.csproj" />
   </ItemGroup>
 

--- a/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
+++ b/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
@@ -4,13 +4,33 @@ using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
 using Typewriter.Application.Orchestration;
+using Typewriter.Generation.Output;
 using Typewriter.Metadata.Roslyn;
 using Xunit;
 
 namespace Typewriter.UnitTests.Cli;
 
-public class CliContractTests
+public class CliContractTests : IDisposable
 {
+    private readonly List<string> _tempFiles = new();
+
+    /// <summary>Creates a minimal temporary <c>.tst</c> file and returns its absolute path.</summary>
+    private string CreateTempTemplate(string content = "$Classes[$Name]")
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"tw_test_{Guid.NewGuid():N}.tst");
+        File.WriteAllText(path, content);
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        foreach (var f in _tempFiles)
+        {
+            try { File.Delete(f); } catch { /* best-effort cleanup */ }
+        }
+    }
+
     private sealed class FakeDiagnosticReporter : IDiagnosticReporter
     {
         private int _warningCount;
@@ -30,6 +50,22 @@ public class CliContractTests
 
         public int WarningCount => _warningCount;
         public int ErrorCount => _errorCount;
+    }
+
+    /// <summary>Diagnostic reporter that captures messages for assertion.</summary>
+    private sealed class CapturingDiagnosticReporter : IDiagnosticReporter
+    {
+        private readonly List<DiagnosticMessage> _messages;
+
+        public CapturingDiagnosticReporter(List<DiagnosticMessage> messages)
+        {
+            _messages = messages;
+        }
+
+        public void Report(DiagnosticMessage message) => _messages.Add(message);
+
+        public int WarningCount => _messages.Count(m => m.Severity == DiagnosticSeverity.Warning);
+        public int ErrorCount => _messages.Count(m => m.Severity == DiagnosticSeverity.Error);
     }
 
     /// <summary>Input resolver stub that always returns a successful resolved input.</summary>
@@ -75,12 +111,28 @@ public class CliContractTests
             => Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult([]));
     }
 
+    /// <summary>Output writer stub that records written files without touching disk.</summary>
+    private sealed class StubOutputWriter : IOutputWriter
+    {
+        public Task WriteAsync(string filePath, string content, bool addBom, CancellationToken ct)
+            => Task.CompletedTask;
+    }
+
+    /// <summary>Output path policy stub that returns a deterministic path.</summary>
+    private sealed class StubOutputPathPolicy : IOutputPathPolicy
+    {
+        public string Resolve(string templatePath, string sourceCsPath, int collisionIndex = 0)
+            => Path.ChangeExtension(sourceCsPath, ".ts");
+    }
+
     private static ApplicationRunner CreateRunner()
         => new ApplicationRunner(
             new StubInputResolver(),
             new StubRestoreService(),
             new StubProjectGraphService(),
-            new StubRoslynWorkspaceService());
+            new StubRoslynWorkspaceService(),
+            new StubOutputWriter(),
+            new StubOutputPathPolicy());
 
     [Fact]
     public async Task Generate_InvalidArgs_Returns2()
@@ -113,10 +165,11 @@ public class CliContractTests
         var runner = CreateRunner();
         // Pre-seed the reporter with 1 warning to simulate a prior warning being reported.
         var reporter = new FakeDiagnosticReporter(warningCount: 1);
+        var templatePath = CreateTempTemplate();
 
         var options = GenerateCommandOptions.Merge(
             config:        null,
-            templates:     ["tmpl.tst"],
+            templates:     [templatePath],
             solution:      "my.sln",
             project:       null,
             framework:     null,
@@ -130,5 +183,59 @@ public class CliContractTests
         var exitCode = await runner.RunAsync(options, reporter);
 
         Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Generate_EmptyWorkspace_Returns0()
+    {
+        // An empty workspace (no .cs files) means no metadata to render → still succeeds.
+        var runner = CreateRunner();
+        var reporter = new FakeDiagnosticReporter();
+        var templatePath = CreateTempTemplate();
+
+        var options = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     [templatePath],
+            solution:      "my.sln",
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(0, reporter.ErrorCount);
+    }
+
+    [Fact]
+    public async Task Generate_NonExistentTemplate_Returns1WithTW3001()
+    {
+        // A non-existent template file is caught by the file-existence check → TW3001.
+        var runner = CreateRunner();
+        var messages = new List<DiagnosticMessage>();
+        var reporter = new CapturingDiagnosticReporter(messages);
+
+        var options = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     ["/nonexistent/path/template.tst"],
+            solution:      "my.sln",
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(messages, m => m.Code == DiagnosticCode.TW3001);
     }
 }

--- a/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
+++ b/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
@@ -5,14 +5,27 @@ using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
 using Typewriter.Application.Orchestration;
+using Typewriter.Generation.Output;
 using Typewriter.Metadata.Roslyn;
 using Xunit;
 
 namespace Typewriter.UnitTests.Loading;
 
-public class ProjectLoaderTests
+public class ProjectLoaderTests : IDisposable
 {
     private const string ProjectPath = "SimpleLib/SimpleLib.csproj";
+    private readonly string _templatePath;
+
+    public ProjectLoaderTests()
+    {
+        _templatePath = Path.Combine(Path.GetTempPath(), $"tw_test_{Guid.NewGuid():N}.tst");
+        File.WriteAllText(_templatePath, "$Classes[$Name]");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_templatePath); } catch { /* best-effort cleanup */ }
+    }
 
     private static ProjectLoadPlan ValidPlan(string projectPath) =>
         new ProjectLoadPlan(
@@ -21,10 +34,10 @@ public class ProjectLoaderTests
             [new LoadTarget(projectPath, "SimpleLib", "net10.0", null, null, 0)],
             new Dictionary<string, string>());
 
-    private static GenerateCommandOptions MakeOptions(bool restore, string project = ProjectPath) =>
+    private GenerateCommandOptions MakeOptions(bool restore, string project = ProjectPath) =>
         GenerateCommandOptions.Merge(
             config: null,
-            templates: ["tmpl.tst"],
+            templates: [_templatePath],
             solution: null,
             project: project,
             framework: null,
@@ -67,7 +80,7 @@ public class ProjectLoaderTests
             .LoadAsync(Arg.Any<ProjectLoadPlan>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult([])));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService);
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>());
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
@@ -97,7 +110,7 @@ public class ProjectLoaderTests
             .CheckAssetsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService);
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>());
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
@@ -143,7 +156,7 @@ public class ProjectLoaderTests
             .LoadAsync(Arg.Any<ProjectLoadPlan>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult([])));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService);
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>());
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: true), reporter);


### PR DESCRIPTION
## Summary
- Wires the complete template execution step into `ApplicationRunner.RunAsync` after workspace load
- Adds `IOutputWriter` and `IOutputPathPolicy` as constructor dependencies for testability
- Validates template file existence (TW3001) before execution
- Creates `RoslynMetadataProvider` from `WorkspaceLoadResult` and iterates `IFileMetadata` results
- Handles single-file vs per-file template modes based on `template.Settings.IsSingleFileMode`
- Catches template compilation errors (TW3001) and assembly load failures (TW3002) with exit code 1
- Skips template compilation when workspace has no source files (empty workspace → success)
- Updates `Program.cs` to compose `OutputWriter` and `OutputPathPolicy`
- Updates all existing test call sites for the new constructor signature
- Adds tests for empty workspace success and missing template file error

Closes #150

## Test plan
- [x] `dotnet build -c Release` succeeds with 0 warnings
- [x] `dotnet test -c Release` passes all 169 tests (154 unit + 13 integration + 1 golden + 1 perf)
- [x] `Generate_EmptyWorkspace_Returns0` — empty workspace with valid template → exit 0
- [x] `Generate_NonExistentTemplate_Returns1WithTW3001` — missing template → TW3001, exit 1
- [x] `Generate_WarningsWithFailFlag_Returns1` — warnings with --fail-on-warnings → exit 1
- [x] Existing `ProjectLoaderTests` updated and passing with temp .tst files

🤖 Generated with [Claude Code](https://claude.com/claude-code)