### PR TITLE
feat: add Verify.Xunit to GoldenTests project (M7)

### DIFF
--- a/tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj
+++ b/tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Verify.Xunit" Version="28.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <!-- Suppress MSBL001: Microsoft.Build.* packages flow transitively via Typewriter.Loading.MSBuild; runtime managed by MsBuildLocatorService -->
     <PackageReference Include="Microsoft.Build" Version="17.*" ExcludeAssets="runtime" />


### PR DESCRIPTION
## Summary
- Adds `Verify.Xunit` (version `28.*`) NuGet package reference to `tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj`
- Enables snapshot-based golden testing for the GoldenTests project (M7 prerequisite)
- No other package changes

## Verification
- `dotnet restore` succeeds and `Verify.Xunit` resolves
- `dotnet build -c Release` succeeds with 0 errors/0 warnings
- `dotnet test -c Release` passes all 172 tests (157 unit + 13 integration + 1 golden + 1 performance)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)