### PR TITLE
feat: add multi-project fixture for golden tests (M7, #155)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-04 by Claude (Executor, #152)
+> Last touched: 2026-03-04 by Claude (Executor, #155)
 
 ## Current State
 
 - **Active milestone**: M7 - Golden parity and fixture repos
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Create fixture directories and golden test infrastructure based on T152 review
+- **Next step**: Create remaining M7 fixture sets (simple, multi-target, source-generators, complex-types)
 
 ## Milestone Map
 
@@ -103,6 +103,7 @@
 | #150 Wire template execution into ApplicationRunner | M6 | Executor | Done | `ApplicationRunner` gains `IOutputWriter` + `IOutputPathPolicy` deps; template execution loop after workspace load: validates .tst files, creates `RoslynMetadataProvider`, iterates `IFileMetadata`, handles single-file vs per-file mode, TW3001/TW3002 errors; all callers updated; build 0 errors/0 warnings, 169/169 tests pass |
 | #151 Run M6 acceptance criteria verification | M6 | Executor | Done | restore/build/test all pass; 170/170 tests (157 unit + 13 integration); TemplateEngineTests 3/3, OutputPolicyTests 3/3, AssemblyLoadContextTests 7/7; Placeholder.cs deleted; zero VS coupling in Generation/ source; origin/ unchanged; M6→Done, active milestone→M7 |
 | #152 Review origin/ for fixture templates (M7) | M7 | Executor | Done | [T152-m7-fixture-review.md](.ai/tasks/T152-m7-fixture-review.md) — catalogued 6 templates, 3 golden files, 14+ input types; mapped to 5 M7 fixture sets (simple, multi-project, multi-target, source-generators, complex-types); documented parity tags (identical/transformed/deferred) |
+| #155 Create multi-project fixture (M7) | M7 | Executor | Done | `tests/fixtures/multi-project/` — MultiProject.sln with DomainLib (IEntity, EntityBase, Address) and ApiLib (UserEntity, OrderEntity → EntityBase); CrossProjectTypes.tst traverses cross-project references; dotnet restore/build verified |
 
 ## Decisions
 

--- a/tests/fixtures/multi-project/ApiLib/ApiLib.csproj
+++ b/tests/fixtures/multi-project/ApiLib/ApiLib.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainLib\DomainLib.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/fixtures/multi-project/ApiLib/OrderEntity.cs
+++ b/tests/fixtures/multi-project/ApiLib/OrderEntity.cs
@@ -1,0 +1,24 @@
+using DomainLib;
+
+namespace ApiLib;
+
+/// <summary>
+/// Order entity that extends EntityBase from DomainLib.
+/// </summary>
+public class OrderEntity : EntityBase
+{
+    /// <summary>
+    /// Gets or sets the product name.
+    /// </summary>
+    public string ProductName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the order amount.
+    /// </summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the customer who placed the order (same-project type reference).
+    /// </summary>
+    public UserEntity Customer { get; set; } = new();
+}

--- a/tests/fixtures/multi-project/ApiLib/UserEntity.cs
+++ b/tests/fixtures/multi-project/ApiLib/UserEntity.cs
@@ -1,0 +1,24 @@
+using DomainLib;
+
+namespace ApiLib;
+
+/// <summary>
+/// User entity that extends EntityBase from DomainLib.
+/// </summary>
+public class UserEntity : EntityBase
+{
+    /// <summary>
+    /// Gets or sets the user's display name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the user's email address.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the user's home address (cross-project type reference).
+    /// </summary>
+    public Address HomeAddress { get; set; } = new();
+}

--- a/tests/fixtures/multi-project/CrossProjectTypes.tst
+++ b/tests/fixtures/multi-project/CrossProjectTypes.tst
@@ -1,0 +1,33 @@
+${
+    using Typewriter.Extensions.Types;
+
+    string BaseClassName(Class c)
+    {
+        return c.BaseClass != null ? c.BaseClass.Name : "none";
+    }
+
+    string ImplementedInterfaces(Class c)
+    {
+        return string.Join(", ", c.Interfaces.Select(i => i.Name));
+    }
+}
+// Auto-generated from multi-project solution
+// This template traverses cross-project references:
+//   - DomainLib defines IEntity, EntityBase, Address
+//   - ApiLib defines UserEntity and OrderEntity (extend EntityBase, use Address)
+
+$Classes(*Entity)[
+// $FullName
+export class $Name {
+    // Base: $BaseClassName
+    // Implements: $ImplementedInterfaces
+    $Properties[
+    $name: $Type;]
+}
+]
+$Interfaces(IEntity)[
+export interface $Name {
+    $Properties[
+    $name: $Type;]
+}
+]

--- a/tests/fixtures/multi-project/DomainLib/Address.cs
+++ b/tests/fixtures/multi-project/DomainLib/Address.cs
@@ -1,0 +1,22 @@
+namespace DomainLib;
+
+/// <summary>
+/// Value object representing a postal address.
+/// </summary>
+public class Address
+{
+    /// <summary>
+    /// Gets or sets the street line.
+    /// </summary>
+    public string Street { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the city name.
+    /// </summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the postal/zip code.
+    /// </summary>
+    public string ZipCode { get; set; } = string.Empty;
+}

--- a/tests/fixtures/multi-project/DomainLib/DomainLib.csproj
+++ b/tests/fixtures/multi-project/DomainLib/DomainLib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/fixtures/multi-project/DomainLib/EntityBase.cs
+++ b/tests/fixtures/multi-project/DomainLib/EntityBase.cs
@@ -1,0 +1,17 @@
+namespace DomainLib;
+
+/// <summary>
+/// Abstract base class for all domain entities.
+/// </summary>
+public abstract class EntityBase : IEntity
+{
+    /// <summary>
+    /// Gets or sets the unique identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the creation timestamp.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+}

--- a/tests/fixtures/multi-project/DomainLib/IEntity.cs
+++ b/tests/fixtures/multi-project/DomainLib/IEntity.cs
@@ -1,0 +1,12 @@
+namespace DomainLib;
+
+/// <summary>
+/// Base entity interface with an identifier.
+/// </summary>
+public interface IEntity
+{
+    /// <summary>
+    /// Gets or sets the unique identifier.
+    /// </summary>
+    int Id { get; set; }
+}

--- a/tests/fixtures/multi-project/MultiProject.sln
+++ b/tests/fixtures/multi-project/MultiProject.sln
@@ -1,0 +1,28 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainLib", "DomainLib\DomainLib.csproj", "{B1C2D3E4-0001-0001-0001-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiLib", "ApiLib\ApiLib.csproj", "{B1C2D3E4-0002-0002-0002-000000000002}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B1C2D3E4-0001-0001-0001-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C2D3E4-0001-0001-0001-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C2D3E4-0001-0001-0001-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-0001-0001-0001-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1C2D3E4-0002-0002-0002-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C2D3E4-0002-0002-0002-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C2D3E4-0002-0002-0002-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-0002-0002-0002-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- Creates `tests/fixtures/multi-project/` — a `.sln` fixture with 2 interdependent projects to test cross-project reference resolution in templates
- **DomainLib**: defines `IEntity` interface, `EntityBase` abstract class, and `Address` value object
- **ApiLib**: references DomainLib; `UserEntity` and `OrderEntity` extend `EntityBase` and use `Address` (cross-project type references)
- **CrossProjectTypes.tst**: template that traverses cross-project references — iterates `*Entity` classes showing base class resolution and interface listing across project boundaries
- Both projects target `net10.0`

Closes #155

## Acceptance criteria verified
- `dotnet restore tests/fixtures/multi-project/MultiProject.sln` succeeds
- `dotnet build tests/fixtures/multi-project/MultiProject.sln` succeeds (0 warnings, 0 errors)
- Cross-project reference (ApiLib → DomainLib) is resolvable in Roslyn workspace
- Template references types from both projects (EntityBase, IEntity, Address from DomainLib; UserEntity, OrderEntity from ApiLib)
- Full solution: restore, build, test all pass (172 tests: 157 unit + 13 integration + 1 golden + 1 performance)

## Test plan
- [x] `dotnet restore tests/fixtures/multi-project/MultiProject.sln` succeeds
- [x] `dotnet build tests/fixtures/multi-project/MultiProject.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet restore` (full solution) succeeds
- [x] `dotnet build -c Release` (full solution) — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 172/172 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)