### PR TITLE
feat: implement golden test runner for baseline comparison (M7, #161)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-04 by Claude (Executor, #160)
+> Last touched: 2026-03-04 by Claude (Executor, #161)
 
 ## Current State
 
 - **Active milestone**: M7 - Golden parity and fixture repos
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Complete remaining M7 tasks (golden test harness)
+- **Next step**: Complete remaining M7 acceptance criteria verification
 
 ## Milestone Map
 
@@ -20,7 +20,7 @@
 | M4 | MSBuild loading: `.sln` and `.slnx` | Done | All acceptance criteria verified: restore/build 0 errors, 150/150 tests pass, all 4 SolutionLoaderTests green, TW2110/TW2310 covered, InputResolver accepts .sln/.slnx, origin/ unchanged, zero VS refs |
 | M5 | Semantic model extraction parity | Done | All acceptance criteria verified (#137): restore/build 0 errors/0 warnings, 155/155 tests pass (142 unit + 13 integration), all 6 MetadataParityTests green (incl. SourceGeneratorTypes_AreVisible), RoslynFileMetadata.cs zero VS refs, source-gen fixture green, origin/ unchanged, zero EnvDTE/VS refs |
 | M6 | Template execution and output management | Done | All acceptance criteria verified (#151): restore/build 0 errors/0 warnings, 170/170 tests pass (157 unit + 13 integration), TemplateEngineTests 3/3, OutputPolicyTests 3/3, AssemblyLoadContextTests 7/7, Placeholder.cs deleted, zero VS coupling in Generation/ source, origin/ unchanged |
-| M7 | Golden parity and fixture repos | In progress | Simple (#154), multi-project (#155), multi-target (#156), source-generators (#157), complex-types (#158) fixtures created; ParityMatrix.md (#159) done; baselines captured (#160) |
+| M7 | Golden parity and fixture repos | In progress | Simple (#154), multi-project (#155), multi-target (#156), source-generators (#157), complex-types (#158) fixtures created; ParityMatrix.md (#159) done; baselines captured (#160); golden test runner implemented (#161) |
 | M8 | CI pipelines and release readiness | In progress | eng/versioning.props created (#166) |
 | M9 | Performance and caching hardening | Not started | |
 
@@ -110,6 +110,7 @@
 | #158 Create complex-types fixture (M7) | M7 | Executor | Done | `tests/fixtures/complex-types/ComplexTypesLib/` — net10.0 project with NullableTypes (string?, int?, Guid?), AsyncService (Task\<T\>, Task\<(string,int)\>, defaults), GenericRepository\<T\> (where T : class, new()), PartialEntity (split across 2 files); 2 .tst templates (ComplexModels.tst, AsyncTypes.tst); dotnet restore/build verified |
 | #159 Create ParityMatrix.md (M7) | M7 | Executor | Done | `tests/Typewriter.GoldenTests/ParityMatrix.md` — 12 parity features tagged: 6 identical (class, enum, interface gen; nullable/generic types; partial classes; BOM policy; collision naming), 4 transformed (multi-project refs, TFM selection, source-gen symbols, requestRender batch), 0 deferred; all identical features reference golden test fixtures |
 | #160 Run generation against fixtures and capture baselines (M7) | M7 | Executor | Done | Ran `typewriter-cli generate` against all 5 fixtures (simple, multi-project, multi-target, source-generators, complex-types); captured 12 baseline .ts files in `tests/baselines/`; LF line endings enforced via `.gitattributes`; fixed SourceGenTypes.tst predicate filter syntax (`$IsSourceGenLib`); fixed TemplateAssemblyLoadContext to defer to default context for shared assemblies; fixed ShadowClass compilation to include System.Runtime/Collections/netstandard refs; fixed Parser extension method lookup via GetMethods+IsAssignableFrom; fixed ProjectGraphService JIT-safety via NoInlining wrapper; 174/174 tests pass |
+| #161 Implement golden test runner (M7) | M7 | Executor | Done | `GoldenTestBase` infrastructure class with `CapturingOutputWriter` and `TestDiagnosticReporter`; 5 per-fixture test classes (GoldenTest_Simple, GoldenTest_MultiProject, GoldenTest_MultiTarget, GoldenTest_SourceGenerators, GoldenTest_ComplexTypes); all 5 golden tests pass against committed baselines; xunit.runner.json disables parallel test collections; 179/179 tests pass |
 
 ## Decisions
 

--- a/tests/Typewriter.GoldenTests/GoldenTest_ComplexTypes.cs
+++ b/tests/Typewriter.GoldenTests/GoldenTest_ComplexTypes.cs
@@ -1,0 +1,28 @@
+using Typewriter.GoldenTests.Infrastructure;
+using Xunit;
+
+namespace Typewriter.GoldenTests;
+
+/// <summary>
+/// Golden tests for the <c>complex-types</c> fixture — nullable types, generics,
+/// partial classes, async Task unwrapping, and collision naming.
+/// </summary>
+public class GoldenTest_ComplexTypes : GoldenTestBase
+{
+    [Fact]
+    public async Task ComplexTypes_GenerationMatchesBaselines()
+    {
+        var templatePaths = new[]
+        {
+            FixturePath("complex-types", "ComplexTypesLib", "ComplexModels.tst"),
+            FixturePath("complex-types", "ComplexTypesLib", "AsyncTypes.tst"),
+        };
+
+        var result = await RunGenerationAsync(
+            templatePaths,
+            projectPath: FixturePath("complex-types", "ComplexTypesLib", "ComplexTypesLib.csproj"),
+            restore: true);
+
+        AssertMatchesBaselines(result, BaselinePath("complex-types"));
+    }
+}

--- a/tests/Typewriter.GoldenTests/GoldenTest_MultiProject.cs
+++ b/tests/Typewriter.GoldenTests/GoldenTest_MultiProject.cs
@@ -1,0 +1,27 @@
+using Typewriter.GoldenTests.Infrastructure;
+using Xunit;
+
+namespace Typewriter.GoldenTests;
+
+/// <summary>
+/// Golden tests for the <c>multi-project</c> fixture — cross-project type references
+/// between DomainLib and ApiLib via a solution file.
+/// </summary>
+public class GoldenTest_MultiProject : GoldenTestBase
+{
+    [Fact]
+    public async Task MultiProject_GenerationMatchesBaselines()
+    {
+        var templatePaths = new[]
+        {
+            FixturePath("multi-project", "CrossProjectTypes.tst"),
+        };
+
+        var result = await RunGenerationAsync(
+            templatePaths,
+            solutionPath: FixturePath("multi-project", "MultiProject.sln"),
+            restore: true);
+
+        AssertMatchesBaselines(result, BaselinePath("multi-project"));
+    }
+}

--- a/tests/Typewriter.GoldenTests/GoldenTest_MultiTarget.cs
+++ b/tests/Typewriter.GoldenTests/GoldenTest_MultiTarget.cs
@@ -1,0 +1,26 @@
+using Typewriter.GoldenTests.Infrastructure;
+using Xunit;
+
+namespace Typewriter.GoldenTests;
+
+/// <summary>
+/// Golden tests for the <c>multi-target</c> fixture — dual-target TFM selection (net10.0;net8.0).
+/// </summary>
+public class GoldenTest_MultiTarget : GoldenTestBase
+{
+    [Fact]
+    public async Task MultiTarget_GenerationMatchesBaselines()
+    {
+        var templatePaths = new[]
+        {
+            FixturePath("multi-target", "MultiTargetLib", "PlatformInfo.tst"),
+        };
+
+        var result = await RunGenerationAsync(
+            templatePaths,
+            projectPath: FixturePath("multi-target", "MultiTargetLib", "MultiTargetLib.csproj"),
+            restore: true);
+
+        AssertMatchesBaselines(result, BaselinePath("multi-target"));
+    }
+}

--- a/tests/Typewriter.GoldenTests/GoldenTest_Simple.cs
+++ b/tests/Typewriter.GoldenTests/GoldenTest_Simple.cs
@@ -1,0 +1,27 @@
+using Typewriter.GoldenTests.Infrastructure;
+using Xunit;
+
+namespace Typewriter.GoldenTests;
+
+/// <summary>
+/// Golden tests for the <c>simple</c> fixture — basic class, enum, and interface generation.
+/// </summary>
+public class GoldenTest_Simple : GoldenTestBase
+{
+    [Fact]
+    public async Task Simple_GenerationMatchesBaselines()
+    {
+        var templatePaths = new[]
+        {
+            FixturePath("simple", "SimpleProject", "Enums.tst"),
+            FixturePath("simple", "SimpleProject", "Interfaces.tst"),
+        };
+
+        var result = await RunGenerationAsync(
+            templatePaths,
+            projectPath: FixturePath("simple", "SimpleProject", "SimpleProject.csproj"),
+            restore: true);
+
+        AssertMatchesBaselines(result, BaselinePath("simple"));
+    }
+}

--- a/tests/Typewriter.GoldenTests/GoldenTest_SourceGenerators.cs
+++ b/tests/Typewriter.GoldenTests/GoldenTest_SourceGenerators.cs
@@ -1,0 +1,27 @@
+using Typewriter.GoldenTests.Infrastructure;
+using Xunit;
+
+namespace Typewriter.GoldenTests;
+
+/// <summary>
+/// Golden tests for the <c>source-generators</c> fixture — validates visibility
+/// of source-generator-produced types in the template metadata pipeline.
+/// </summary>
+public class GoldenTest_SourceGenerators : GoldenTestBase
+{
+    [Fact]
+    public async Task SourceGenerators_GenerationMatchesBaselines()
+    {
+        var templatePaths = new[]
+        {
+            FixturePath("source-generators", "SourceGenTypes.tst"),
+        };
+
+        var result = await RunGenerationAsync(
+            templatePaths,
+            projectPath: FixturePath("source-generators", "SourceGenLib", "SourceGenLib.csproj"),
+            restore: true);
+
+        AssertMatchesBaselines(result, BaselinePath("source-generators"));
+    }
+}

--- a/tests/Typewriter.GoldenTests/Infrastructure/CapturingOutputWriter.cs
+++ b/tests/Typewriter.GoldenTests/Infrastructure/CapturingOutputWriter.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+using Typewriter.Generation.Output;
+
+namespace Typewriter.GoldenTests.Infrastructure;
+
+/// <summary>
+/// An <see cref="IOutputWriter"/> that captures generated output in memory
+/// instead of writing to disk, enabling golden test comparison.
+/// </summary>
+internal sealed class CapturingOutputWriter : IOutputWriter
+{
+    private readonly ConcurrentDictionary<string, string> _outputs = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the captured outputs keyed by file path.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Outputs => _outputs;
+
+    /// <inheritdoc />
+    public Task WriteAsync(string filePath, string content, bool addBom, CancellationToken ct)
+    {
+        _outputs[filePath] = content;
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Typewriter.GoldenTests/Infrastructure/GoldenTestBase.cs
+++ b/tests/Typewriter.GoldenTests/Infrastructure/GoldenTestBase.cs
@@ -1,0 +1,178 @@
+using Typewriter.Application;
+using Typewriter.Application.Diagnostics;
+using Typewriter.Generation.Output;
+using Typewriter.Loading.MSBuild;
+using Xunit;
+
+namespace Typewriter.GoldenTests.Infrastructure;
+
+/// <summary>
+/// Base class for golden tests. Provides shared infrastructure for MSBuild registration,
+/// fixture path resolution, generation execution, and baseline comparison.
+/// </summary>
+public abstract class GoldenTestBase : IAsyncLifetime
+{
+    private static readonly MsBuildLocatorService Locator = new();
+    private static readonly object LocatorLock = new();
+    private static bool _locatorRegistered;
+
+    /// <summary>
+    /// Resolves an absolute path to a file under the <c>tests/</c> directory.
+    /// </summary>
+    protected static string TestsPath(params string[] segments)
+    {
+        var parts = new[] { AppContext.BaseDirectory, "..", "..", "..", "..", ".." , "tests" };
+        return Path.GetFullPath(Path.Combine([.. parts, .. segments]));
+    }
+
+    /// <summary>
+    /// Resolves an absolute path to a fixture directory.
+    /// </summary>
+    protected static string FixturePath(params string[] segments) =>
+        TestsPath(["fixtures", .. segments]);
+
+    /// <summary>
+    /// Resolves an absolute path to a baseline directory.
+    /// </summary>
+    protected static string BaselinePath(params string[] segments) =>
+        TestsPath(["baselines", .. segments]);
+
+    /// <inheritdoc />
+    public Task InitializeAsync()
+    {
+        EnsureMsBuildRegistered();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static void EnsureMsBuildRegistered()
+    {
+        if (_locatorRegistered) return;
+        lock (LocatorLock)
+        {
+            if (_locatorRegistered) return;
+            var reporter = new TestDiagnosticReporter();
+            Locator.EnsureRegistered(reporter);
+            _locatorRegistered = true;
+        }
+    }
+
+    /// <summary>
+    /// Runs the generation pipeline for a fixture and returns captured outputs.
+    /// </summary>
+    /// <param name="templatePaths">Absolute paths to <c>.tst</c> template files.</param>
+    /// <param name="projectPath">Absolute path to the <c>.csproj</c> file, or <c>null</c> when using a solution.</param>
+    /// <param name="solutionPath">Absolute path to the <c>.sln</c> file, or <c>null</c> when using a project.</param>
+    /// <param name="restore">Whether to run <c>dotnet restore</c> before loading.</param>
+    /// <returns>A dictionary of output file paths to their generated content.</returns>
+    protected static async Task<GoldenTestResult> RunGenerationAsync(
+        IReadOnlyList<string> templatePaths,
+        string? projectPath = null,
+        string? solutionPath = null,
+        bool restore = false)
+    {
+        var reporter = new TestDiagnosticReporter();
+        var capturingWriter = new CapturingOutputWriter();
+
+        var inputResolver = new InputResolver();
+        var restoreService = new RestoreService();
+        var solutionFallbackService = new SolutionFallbackService();
+        var projectGraphService = new ProjectGraphService(Locator, solutionFallbackService);
+        var roslynWorkspaceService = new RoslynWorkspaceService();
+        var outputPathPolicy = new OutputPathPolicy();
+
+        var runner = new ApplicationRunner(
+            inputResolver,
+            restoreService,
+            projectGraphService,
+            roslynWorkspaceService,
+            capturingWriter,
+            outputPathPolicy);
+
+        var options = new GenerateCommandOptions(
+            Templates: templatePaths,
+            Solution: solutionPath,
+            Project: projectPath,
+            Framework: null,
+            Configuration: null,
+            Runtime: null,
+            Restore: restore,
+            Output: null,
+            Verbosity: "normal",
+            FailOnWarnings: false);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        return new GoldenTestResult(exitCode, capturingWriter.Outputs, reporter);
+    }
+
+    /// <summary>
+    /// Compares all generated output files against committed baselines.
+    /// Fails on content mismatch, missing baseline files, or unexpected extra files.
+    /// </summary>
+    /// <param name="result">The generation result containing captured outputs.</param>
+    /// <param name="baselineDir">Absolute path to the baseline directory for this fixture.</param>
+    protected static void AssertMatchesBaselines(GoldenTestResult result, string baselineDir)
+    {
+        Assert.Equal(0, result.ExitCode);
+
+        var baselineFiles = Directory.Exists(baselineDir)
+            ? Directory.GetFiles(baselineDir, "*.ts")
+                .ToDictionary(f => Path.GetFileName(f), f => f, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var generatedFiles = result.Outputs
+            .ToDictionary(
+                kvp => Path.GetFileName(kvp.Key),
+                kvp => kvp.Value,
+                StringComparer.OrdinalIgnoreCase);
+
+        // Check for missing baseline files (generated but no baseline).
+        var unexpectedFiles = generatedFiles.Keys.Except(baselineFiles.Keys, StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.True(
+            unexpectedFiles.Count == 0,
+            $"Unexpected generated files with no baseline: {string.Join(", ", unexpectedFiles)}");
+
+        // Check for missing generated files (baseline exists but not generated).
+        var missingFiles = baselineFiles.Keys.Except(generatedFiles.Keys, StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.True(
+            missingFiles.Count == 0,
+            $"Missing generated files that have baselines: {string.Join(", ", missingFiles)}");
+
+        // Compare content of each file.
+        foreach (var (fileName, baselinePath) in baselineFiles)
+        {
+            Assert.True(
+                generatedFiles.ContainsKey(fileName),
+                $"Generated output missing for baseline file: {fileName}");
+
+            var expectedContent = NormalizeLineEndings(File.ReadAllText(baselinePath));
+            var actualContent = NormalizeLineEndings(generatedFiles[fileName]);
+
+            Assert.True(
+                string.Equals(expectedContent, actualContent, StringComparison.Ordinal),
+                $"Content mismatch for '{fileName}'.\n" +
+                $"--- Expected (baseline) ---\n{expectedContent}\n" +
+                $"--- Actual (generated) ---\n{actualContent}");
+        }
+    }
+
+    /// <summary>
+    /// Normalizes line endings to LF for cross-platform comparison.
+    /// </summary>
+    private static string NormalizeLineEndings(string text) =>
+        text.Replace("\r\n", "\n").Replace("\r", "\n");
+}
+
+/// <summary>
+/// Holds the result of a golden test generation run.
+/// </summary>
+/// <param name="ExitCode">The exit code returned by <see cref="ApplicationRunner.RunAsync"/>.</param>
+/// <param name="Outputs">Captured output files keyed by absolute path.</param>
+/// <param name="Reporter">The diagnostic reporter with collected messages.</param>
+public record GoldenTestResult(
+    int ExitCode,
+    IReadOnlyDictionary<string, string> Outputs,
+    TestDiagnosticReporter Reporter);

--- a/tests/Typewriter.GoldenTests/Infrastructure/TestDiagnosticReporter.cs
+++ b/tests/Typewriter.GoldenTests/Infrastructure/TestDiagnosticReporter.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+using Typewriter.Application.Diagnostics;
+
+namespace Typewriter.GoldenTests.Infrastructure;
+
+/// <summary>
+/// A diagnostic reporter for golden tests that collects all messages
+/// and tracks warning/error counts.
+/// </summary>
+public sealed class TestDiagnosticReporter : IDiagnosticReporter
+{
+    private readonly ConcurrentBag<DiagnosticMessage> _messages = [];
+    private int _warningCount;
+    private int _errorCount;
+
+    /// <inheritdoc />
+    public void Report(DiagnosticMessage message)
+    {
+        _messages.Add(message);
+        if (message.Severity == DiagnosticSeverity.Warning)
+            Interlocked.Increment(ref _warningCount);
+        else if (message.Severity == DiagnosticSeverity.Error)
+            Interlocked.Increment(ref _errorCount);
+    }
+
+    /// <inheritdoc />
+    public int WarningCount => _warningCount;
+
+    /// <inheritdoc />
+    public int ErrorCount => _errorCount;
+
+    /// <summary>
+    /// Gets all collected diagnostic messages.
+    /// </summary>
+    public IReadOnlyList<DiagnosticMessage> Messages => [.. _messages];
+}

--- a/tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj
+++ b/tests/Typewriter.GoldenTests/Typewriter.GoldenTests.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
     <PackageReference Include="Verify.Xunit" Version="28.*" />

--- a/tests/Typewriter.GoldenTests/xunit.runner.json
+++ b/tests/Typewriter.GoldenTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## Summary
- Implements per-fixture golden test classes (`GoldenTest_Simple`, `GoldenTest_MultiProject`, `GoldenTest_MultiTarget`, `GoldenTest_SourceGenerators`, `GoldenTest_ComplexTypes`) that invoke the generation pipeline in-process via `ApplicationRunner`
- Adds `CapturingOutputWriter` for in-memory output capture, `TestDiagnosticReporter` for diagnostic collection, and `GoldenTestBase` with shared MSBuild registration and baseline comparison logic
- Tests fail on any content mismatch, missing baseline files, or unexpected generated files
- Disables parallel test collections via `xunit.runner.json` for MSBuild locator compatibility

## Test plan
- [x] `dotnet restore` succeeds
- [x] `dotnet build -c Release` succeeds with 0 errors/0 warnings
- [x] `dotnet test -c Release` passes all 179 tests (159 unit + 13 integration + 6 golden + 1 perf placeholder)
- [x] All 5 golden tests pass against committed baselines
- [x] Cross-platform line ending normalization ensures tests pass on Windows, Ubuntu, and macOS

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)