### PR TITLE
feat: implement deterministic EOL normalization in golden tests (M7, #162)

### DIFF
--- a/tests/Typewriter.GoldenTests/Infrastructure/GoldenTestBase.cs
+++ b/tests/Typewriter.GoldenTests/Infrastructure/GoldenTestBase.cs
@@ -142,6 +142,7 @@ public abstract class GoldenTestBase : IAsyncLifetime
             $"Missing generated files that have baselines: {string.Join(", ", missingFiles)}");
 
         // Compare content of each file.
+        // Normalize EOL on both sides to prevent Windows CRLF vs Linux LF false positives.
         foreach (var (fileName, baselinePath) in baselineFiles)
         {
             Assert.True(
@@ -160,8 +161,16 @@ public abstract class GoldenTestBase : IAsyncLifetime
     }
 
     /// <summary>
-    /// Normalizes line endings to LF for cross-platform comparison.
+    /// Normalizes line endings to LF (<c>\n</c>) for deterministic cross-platform comparison.
     /// </summary>
+    /// <remarks>
+    /// Git checkout on Windows may convert LF baselines to CRLF, and generators may emit
+    /// platform-native line endings. Without normalization, identical logical content would
+    /// produce false-positive mismatches across Windows (CRLF) and Linux/macOS (LF).
+    /// This only replaces <c>\r\n</c> and standalone <c>\r</c> sequences; BOM bytes are unaffected.
+    /// </remarks>
+    /// <param name="text">The text content to normalize.</param>
+    /// <returns>The text with all line endings converted to LF.</returns>
     private static string NormalizeLineEndings(string text) =>
         text.Replace("\r\n", "\n").Replace("\r", "\n");
 }


### PR DESCRIPTION
## Summary
- Enhanced documentation on the existing EOL normalization in `GoldenTestBase.cs` to explain **why** normalization is needed (Windows CRLF vs Linux LF false positives)
- Added XML doc `<remarks>` block to `NormalizeLineEndings` covering Git checkout behavior, generator platform-native line endings, and BOM safety
- Added inline comment at the comparison loop call site

The core normalization logic (`Replace("\r\n", "\n").Replace("\r", "\n")`) was already implemented in #161. This task ensures the rationale is clearly documented for maintainability.

## Test plan
- [x] `dotnet build -c Release` succeeds
- [x] `dotnet test -c Release` passes all 179 tests (including 6 golden tests)
- [x] EOL normalization applied to both generated output and baseline content
- [x] BOM bytes unaffected (only `\r\n` and `\r` sequences replaced)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)