### PR TITLE
docs: document golden test baseline update workflow (M7, #163)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-04 by Claude (Executor, #161)
+> Last touched: 2026-03-04 by Claude (Executor, #163)
 
 ## Current State
 
@@ -111,6 +111,7 @@
 | #159 Create ParityMatrix.md (M7) | M7 | Executor | Done | `tests/Typewriter.GoldenTests/ParityMatrix.md` — 12 parity features tagged: 6 identical (class, enum, interface gen; nullable/generic types; partial classes; BOM policy; collision naming), 4 transformed (multi-project refs, TFM selection, source-gen symbols, requestRender batch), 0 deferred; all identical features reference golden test fixtures |
 | #160 Run generation against fixtures and capture baselines (M7) | M7 | Executor | Done | Ran `typewriter-cli generate` against all 5 fixtures (simple, multi-project, multi-target, source-generators, complex-types); captured 12 baseline .ts files in `tests/baselines/`; LF line endings enforced via `.gitattributes`; fixed SourceGenTypes.tst predicate filter syntax (`$IsSourceGenLib`); fixed TemplateAssemblyLoadContext to defer to default context for shared assemblies; fixed ShadowClass compilation to include System.Runtime/Collections/netstandard refs; fixed Parser extension method lookup via GetMethods+IsAssignableFrom; fixed ProjectGraphService JIT-safety via NoInlining wrapper; 174/174 tests pass |
 | #161 Implement golden test runner (M7) | M7 | Executor | Done | `GoldenTestBase` infrastructure class with `CapturingOutputWriter` and `TestDiagnosticReporter`; 5 per-fixture test classes (GoldenTest_Simple, GoldenTest_MultiProject, GoldenTest_MultiTarget, GoldenTest_SourceGenerators, GoldenTest_ComplexTypes); all 5 golden tests pass against committed baselines; xunit.runner.json disables parallel test collections; 179/179 tests pass |
+| #163 Document baseline update workflow (M7) | M7 | Executor | Done | `tests/Typewriter.GoldenTests/README.md` — documents running golden tests, updating baselines (`Verify.UpdateSnapshots=1` + manual process), when to update, CI baseline diff review, and how golden tests work internally |
 
 ## Decisions
 

--- a/tests/Typewriter.GoldenTests/README.md
+++ b/tests/Typewriter.GoldenTests/README.md
@@ -1,0 +1,99 @@
+# Golden Tests
+
+Golden tests verify that the Typewriter generation pipeline produces stable, expected output. Each test runs the full pipeline against a fixture project and compares the generated `.ts` files against committed baselines.
+
+## Directory structure
+
+```
+tests/
+├── baselines/           # Committed baseline .ts files (expected output)
+│   ├── simple/
+│   ├── multi-project/
+│   ├── multi-target/
+│   ├── source-generators/
+│   └── complex-types/
+├── fixtures/            # Input projects and .tst templates
+│   ├── simple/
+│   ├── multi-project/
+│   ├── multi-target/
+│   ├── source-generators/
+│   └── complex-types/
+└── Typewriter.GoldenTests/
+    ├── Infrastructure/  # GoldenTestBase, CapturingOutputWriter, TestDiagnosticReporter
+    ├── GoldenTest_*.cs  # Per-fixture test classes
+    └── ParityMatrix.md  # Parity tracking for upstream feature coverage
+```
+
+## Running golden tests
+
+Run all golden tests:
+
+```bash
+dotnet test tests/Typewriter.GoldenTests/ -c Release
+```
+
+Run a specific fixture test:
+
+```bash
+dotnet test tests/Typewriter.GoldenTests/ -c Release --filter "FullyQualifiedName~GoldenTest_Simple"
+```
+
+## Updating baselines
+
+Update baselines **only** after an intentional change to generation behavior. Do not update baselines to make a failing test pass without understanding why the output changed.
+
+### When to update
+
+- You changed template rendering logic in `Typewriter.Generation`.
+- You changed metadata extraction in `Typewriter.Metadata.Roslyn`.
+- You changed output path policy or collision naming in `Typewriter.Generation.Output`.
+- You added a new fixture or modified an existing fixture's `.tst` templates or source files.
+
+### How to update
+
+Use the `Verify.UpdateSnapshots` flag to accept new output as the baseline:
+
+```bash
+dotnet test tests/Typewriter.GoldenTests/ -c Release -- Verify.UpdateSnapshots=1
+```
+
+Alternatively, you can update baselines manually:
+
+1. Build the solution: `dotnet build -c Release`
+2. Run the CLI against each fixture to regenerate output:
+   ```bash
+   dotnet run --project src/Typewriter.Cli/ -c Release -- generate \
+     "tests/fixtures/simple/SimpleProject/*.tst" \
+     --project tests/fixtures/simple/SimpleProject/SimpleProject.csproj \
+     --output tests/baselines/simple/ --restore
+   ```
+3. Copy the generated `.ts` files into the corresponding `tests/baselines/<fixture>/` directory.
+4. Verify the updated baselines pass: `dotnet test tests/Typewriter.GoldenTests/ -c Release`
+5. Commit the updated baselines in the same PR as the behavior change.
+
+### Review checklist
+
+Before committing updated baselines:
+
+- [ ] Every diff is explained by your behavior change
+- [ ] No unrelated files changed
+- [ ] All golden tests pass with the new baselines
+- [ ] The PR description explains why baselines changed
+
+## Reviewing baseline diffs in CI
+
+The CI workflow (`.github/workflows/ci.yml`) runs golden tests as part of the `Test` step on all three platform targets (Windows, Ubuntu, macOS). When a golden test fails:
+
+1. Open the failing CI run from the PR checks.
+2. Expand the **Test** step in the build log.
+3. The assertion message shows a content diff between the expected baseline and actual generated output, including both `--- Expected (baseline) ---` and `--- Actual (generated) ---` sections.
+4. Use the diff to determine whether the change is intentional or a regression.
+
+## How golden tests work
+
+Each `GoldenTest_*.cs` class extends `GoldenTestBase`, which provides:
+
+- **`RunGenerationAsync`** — runs the full `ApplicationRunner` pipeline (resolve → restore → graph → workspace → render) with a `CapturingOutputWriter` that stores generated output in memory instead of writing to disk.
+- **`AssertMatchesBaselines`** — compares every captured output file against the corresponding file in `tests/baselines/<fixture>/`. Fails on content mismatch, missing baselines, or unexpected extra files. Line endings are normalized to LF for cross-platform consistency.
+
+See `Infrastructure/GoldenTestBase.cs` for the full implementation.


### PR DESCRIPTION
## Summary
- Add `tests/Typewriter.GoldenTests/README.md` documenting the golden test baseline workflow
- Covers running golden tests, updating baselines (`Verify.UpdateSnapshots=1` + manual CLI process), when to update, and how to review baseline diffs in CI
- Documents directory structure (`tests/baselines/`, `tests/fixtures/`) and internal mechanism (`GoldenTestBase`, `AssertMatchesBaselines`)

Closes #163

## Test plan
- [ ] Verify `tests/Typewriter.GoldenTests/README.md` exists with all three workflow steps
- [ ] Verify `Verify.UpdateSnapshots=1` command is documented
- [ ] Verify no test files were modified (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)