### PR TITLE
feat: add NuGet restore cache to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore
         run: dotnet restore Typewriter.Cli.slnx
 


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` step before `dotnet restore` in `.github/workflows/ci.yml`
- Caches `~/.nuget/packages` with key based on `runner.os` + hash of `global.json` and `**/*.csproj`
- Includes prefix-based fallback restore key (`${{ runner.os }}-nuget-`)

Closes #165

## Test plan
- [x] `dotnet restore` succeeds locally after change
- [x] `dotnet build -c Release` succeeds
- [x] `dotnet test -c Release` passes (179 tests)
- [ ] CI workflow runs successfully on all matrix OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)