### PR TITLE
feat: import eng/versioning.props from Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="$(MSBuildThisFileDirectory)eng/versioning.props" />
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- Adds `<Import Project="$(MSBuildThisFileDirectory)eng/versioning.props" />` to `Directory.Build.props` before any `<PropertyGroup>` elements
- Ensures MinVer configuration (tag prefix, default pre-release phase) applies to all projects during build and pack

Closes #170

## Test plan
- [x] `dotnet restore` succeeds
- [x] `dotnet build -c Release` succeeds (0 warnings, 0 errors)
- [x] `dotnet test -c Release` passes (179 tests)
- [x] `dotnet pack -c Release` succeeds — MinVer version applied to all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)