### PR TITLE
feat: add MinVer package reference for tag-based versioning

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,10 @@
+<Project>
+
+  <!-- MinVer auto-selects net10.0 with MSBuild >= 18.0, but the net10.0 binary
+       requires the GA runtime. Force net8.0 which rolls forward via
+       runtimeconfig rollForward:major to the installed pre-release runtime. -->
+  <PropertyGroup Condition="'$(MinVerTargetFramework)' == 'net10.0'">
+    <MinVerTargetFramework>net8.0</MinVerTargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Typewriter.Cli/Typewriter.Cli.csproj
+++ b/src/Typewriter.Cli/Typewriter.Cli.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.*" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.*" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.NET.StringTools" Version="17.*" ExcludeAssets="runtime" />
+    <PackageReference Include="MinVer" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `<PackageReference Include="MinVer" Version="*" PrivateAssets="all" />` to `src/Typewriter.Cli/Typewriter.Cli.csproj` for tag-based versioning
- `PrivateAssets="all"` ensures MinVer is a build-time-only dependency, not bundled at runtime
- Add `Directory.Build.targets` to override MinVer's TFM selection from `net10.0` to `net8.0` — the `net10.0` binary requires the GA runtime while the project uses a pre-release .NET 10 SDK; the `net8.0` binary uses `rollForward:major` to the installed runtime

Closes #169

## Test plan
- [x] `dotnet restore` succeeds (MinVer package resolves)
- [x] `dotnet build -c Release` succeeds
- [x] `dotnet test -c Release` passes (179 tests)
- [x] `dotnet pack -c Release` produces `Typewriter.Cli.0.0.0-alpha.0.98.nupkg` (version from git history, no tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)