### PR TITLE
feat: verify release dry-run locally (M8, #172)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,13 +1,13 @@
 # Progress Tracker
 
-> Last touched: 2026-03-04 by Claude (Executor, #164)
+> Last touched: 2026-03-04 by Claude (Executor, #172)
 
 ## Current State
 
 - **Active milestone**: M8 - CI pipelines and release readiness
 - **Status**: In progress
 - **Blocker**: None
-- **Next step**: Continue M8 tasks (CI pipelines, release readiness)
+- **Next step**: Continue M8 tasks (remaining CI/release items)
 
 ## Milestone Map
 
@@ -113,6 +113,7 @@
 | #161 Implement golden test runner (M7) | M7 | Executor | Done | `GoldenTestBase` infrastructure class with `CapturingOutputWriter` and `TestDiagnosticReporter`; 5 per-fixture test classes (GoldenTest_Simple, GoldenTest_MultiProject, GoldenTest_MultiTarget, GoldenTest_SourceGenerators, GoldenTest_ComplexTypes); all 5 golden tests pass against committed baselines; xunit.runner.json disables parallel test collections; 179/179 tests pass |
 | #163 Document baseline update workflow (M7) | M7 | Executor | Done | `tests/Typewriter.GoldenTests/README.md` — documents running golden tests, updating baselines (`Verify.UpdateSnapshots=1` + manual process), when to update, CI baseline diff review, and how golden tests work internally |
 | #164 Run M7 acceptance criteria (M7) | M7 | Executor | Done | All 179/179 tests pass (159 unit + 13 integration + 6 golden + 1 perf); all 8 `identical` ParityMatrix features have passing golden tests; CI matrix covers Windows/Ubuntu/macOS; origin/ unchanged; M7→Done, active milestone→M8 |
+| #172 Verify release dry-run locally (M8) | M8 | Executor | Done | [T172-verify-release-dryrun.md](.ai/tasks/T172-verify-release-dryrun.md) — `dotnet pack` → local tool install → `typewriter-cli generate` smoke test all pass; reusable script `eng/verify-release-dryrun.sh` created; 179/179 tests pass |
 
 ## Decisions
 

--- a/.ai/tasks/T172-verify-release-dryrun.md
+++ b/.ai/tasks/T172-verify-release-dryrun.md
@@ -1,0 +1,54 @@
+# T172: Verify release dry-run locally (M8)
+- Milestone: M8
+- Status: Done
+- Agent: Executor (Claude)
+- Started: 2026-03-04
+- Completed: 2026-03-04
+
+## Objective
+Verify the end-to-end release dry-run locally: `dotnet pack` → local tool install → `typewriter-cli generate` smoke test.
+
+## Approach
+Run the three-step release flow manually, then capture the exact commands in a reusable `eng/verify-release-dryrun.sh` script.
+
+## Journey
+### 2026-03-04
+1. **Toolchain preflight**: .NET SDK 10.0.100-rc.2.25502.107 available; ICU missing → set `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`.
+2. **dotnet pack -c Release**: Succeeded. Produced `src/Typewriter.Cli/bin/Release/Typewriter.Cli.0.0.0-preview.0.102.nupkg` (~11.9 MB). MinVer computed version from commit count (no git tag → `0.0.0-preview.0.102`). MINVER1008 deprecation warning for `MinVerDefaultPreReleasePhase` noted.
+3. **dotnet tool install --local**: Initial attempt with package ID `typewriter-cli` failed — correct package ID is `Typewriter.Cli` (project name), while `typewriter-cli` is the `ToolCommandName`. Installed successfully with `--add-source ./src/Typewriter.Cli/bin/Release Typewriter.Cli --version 0.0.0-preview.0.102`.
+4. **typewriter-cli generate**: First attempt with glob `**/*.tst` failed with TW3001 — CLI expects explicit file paths, not globs. Fixed by passing explicit `.tst` paths: `tests/fixtures/simple/SimpleProject/Enums.tst` and `Interfaces.tst`. Exit code 0, generated `UserRole.ts` and `UserModel.ts`.
+5. **Verification script**: Created `eng/verify-release-dryrun.sh` with all three steps, version extraction from nupkg filename, output verification, and cleanup trap. Ran end-to-end successfully.
+
+## Exact commands that passed
+```bash
+# 1. Pack
+dotnet pack -c Release
+
+# 2. Install local tool
+dotnet tool install --local \
+    --add-source src/Typewriter.Cli/bin/Release \
+    Typewriter.Cli \
+    --create-manifest-if-needed \
+    --version "0.0.0-preview.0.102"
+
+# 3. Restore fixture and smoke test
+dotnet restore tests/fixtures/simple/SimpleProject/SimpleProject.csproj
+dotnet typewriter-cli generate \
+    tests/fixtures/simple/SimpleProject/Enums.tst \
+    tests/fixtures/simple/SimpleProject/Interfaces.tst \
+    --project tests/fixtures/simple/SimpleProject/SimpleProject.csproj
+# Exit code: 0
+# Generated: UserRole.ts, UserModel.ts
+```
+
+## Outcome
+- All three acceptance criteria met:
+  - `dotnet pack` succeeds → `Typewriter.Cli.0.0.0-preview.0.102.nupkg`
+  - Local tool install succeeds
+  - `typewriter-cli generate` exits with code 0, generates expected `.ts` files
+- Reusable script: `eng/verify-release-dryrun.sh`
+- All 179/179 tests pass (159 unit + 13 integration + 6 golden + 1 perf)
+
+## Follow-ups
+- MINVER1008: Consider updating `MinVerDefaultPreReleasePhase` → `MinVerDefaultPreReleaseIdentifiers` in `eng/versioning.props`
+- CLI does not support glob expansion for template arguments — users must pass explicit paths

--- a/eng/verify-release-dryrun.sh
+++ b/eng/verify-release-dryrun.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Verify the release dry-run locally.
+# Usage: ./eng/verify-release-dryrun.sh
+#
+# Steps:
+#   1. dotnet pack -c Release
+#   2. dotnet tool install --local (from pack output)
+#   3. typewriter-cli generate smoke test
+#   4. Cleanup
+#
+# Exit codes:
+#   0 - all steps passed
+#   1 - a step failed
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PACK_DIR="src/Typewriter.Cli/bin/Release"
+FIXTURE_PROJECT="tests/fixtures/simple/SimpleProject/SimpleProject.csproj"
+FIXTURE_DIR="tests/fixtures/simple/SimpleProject"
+
+cleanup() {
+    echo "--- Cleanup ---"
+    dotnet tool uninstall typewriter.cli --local 2>/dev/null || true
+    rm -f dotnet-tools.json
+    rm -f "$FIXTURE_DIR/UserRole.ts" "$FIXTURE_DIR/UserModel.ts"
+    echo "Cleanup complete."
+}
+
+trap cleanup EXIT
+
+# Step 1: Pack
+echo "=== Step 1: dotnet pack -c Release ==="
+dotnet pack -c Release
+NUPKG=$(ls "$PACK_DIR"/Typewriter.Cli.*.nupkg 2>/dev/null | head -1)
+if [ -z "$NUPKG" ]; then
+    echo "FAIL: No .nupkg found in $PACK_DIR"
+    exit 1
+fi
+VERSION=$(basename "$NUPKG" | sed 's/^Typewriter\.Cli\.//; s/\.nupkg$//')
+echo "PASS: Pack produced $NUPKG (version $VERSION)"
+
+# Step 2: Local tool install
+echo ""
+echo "=== Step 2: dotnet tool install --local ==="
+dotnet tool install --local --add-source "$PACK_DIR" Typewriter.Cli \
+    --create-manifest-if-needed --version "$VERSION"
+echo "PASS: Tool installed successfully"
+
+# Step 3: Restore fixture and smoke test
+echo ""
+echo "=== Step 3: Smoke test — typewriter-cli generate ==="
+dotnet restore "$FIXTURE_PROJECT"
+dotnet typewriter-cli generate \
+    "$FIXTURE_DIR/Enums.tst" \
+    "$FIXTURE_DIR/Interfaces.tst" \
+    --project "$FIXTURE_PROJECT"
+echo "PASS: typewriter-cli generate exited with code 0"
+
+# Verify generated output files exist
+if [ ! -f "$FIXTURE_DIR/UserRole.ts" ] || [ ! -f "$FIXTURE_DIR/UserModel.ts" ]; then
+    echo "FAIL: Expected generated .ts files not found"
+    exit 1
+fi
+echo "PASS: Generated files present: UserRole.ts, UserModel.ts"
+
+echo ""
+echo "=== All steps passed ==="


### PR DESCRIPTION
## Summary
- Verified end-to-end release dry-run: `dotnet pack -c Release` → `dotnet tool install --local` → `typewriter-cli generate` smoke test
- All three acceptance criteria pass: pack produces `.nupkg`, local tool installs, `typewriter-cli generate` exits 0 with generated `.ts` output files
- Added reusable `eng/verify-release-dryrun.sh` script that automates the full flow with cleanup

## Verified commands
```bash
dotnet pack -c Release
# → Typewriter.Cli.0.0.0-preview.0.102.nupkg

dotnet tool install --local --add-source src/Typewriter.Cli/bin/Release \
    Typewriter.Cli --create-manifest-if-needed --version "0.0.0-preview.0.102"

dotnet typewriter-cli generate \
    tests/fixtures/simple/SimpleProject/Enums.tst \
    tests/fixtures/simple/SimpleProject/Interfaces.tst \
    --project tests/fixtures/simple/SimpleProject/SimpleProject.csproj
# → exit code 0, generated UserRole.ts + UserModel.ts
```

## Test plan
- [x] `dotnet pack -c Release` succeeds and produces a `.nupkg`
- [x] Local tool install succeeds
- [x] `typewriter-cli generate` smoke command exits with code 0
- [x] Generated `.ts` files appear in expected output location
- [x] All 179/179 tests pass (159 unit + 13 integration + 6 golden + 1 perf)
- [x] `eng/verify-release-dryrun.sh` runs end-to-end successfully

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)