### PR TITLE
feat: add release.yml tag-triggered workflow (M8, #171)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-04 by Claude (Executor, #172)
+> Last touched: 2026-03-04 by Claude (Executor, #171)
 
 ## Current State
 
@@ -113,6 +113,7 @@
 | #161 Implement golden test runner (M7) | M7 | Executor | Done | `GoldenTestBase` infrastructure class with `CapturingOutputWriter` and `TestDiagnosticReporter`; 5 per-fixture test classes (GoldenTest_Simple, GoldenTest_MultiProject, GoldenTest_MultiTarget, GoldenTest_SourceGenerators, GoldenTest_ComplexTypes); all 5 golden tests pass against committed baselines; xunit.runner.json disables parallel test collections; 179/179 tests pass |
 | #163 Document baseline update workflow (M7) | M7 | Executor | Done | `tests/Typewriter.GoldenTests/README.md` — documents running golden tests, updating baselines (`Verify.UpdateSnapshots=1` + manual process), when to update, CI baseline diff review, and how golden tests work internally |
 | #164 Run M7 acceptance criteria (M7) | M7 | Executor | Done | All 179/179 tests pass (159 unit + 13 integration + 6 golden + 1 perf); all 8 `identical` ParityMatrix features have passing golden tests; CI matrix covers Windows/Ubuntu/macOS; origin/ unchanged; M7→Done, active milestone→M8 |
+| #171 Create release.yml tag-triggered workflow (M8) | M8 | Executor | Done | `.github/workflows/release.yml` — tag-triggered (`v*.*.*`) release workflow with `build-test` (3-OS matrix), `parity-gate` (golden tests), `publish` (NuGet via `NUGET_API_KEY` secret); artifact upload/download for nupkg |
 | #172 Verify release dry-run locally (M8) | M8 | Executor | Done | [T172-verify-release-dryrun.md](.ai/tasks/T172-verify-release-dryrun.md) — `dotnet pack` → local tool install → `typewriter-cli generate` smoke test all pass; reusable script `eng/verify-release-dryrun.sh` created; 179/179 tests pass |
 
 ## Decisions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+jobs:
+  build-test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore Typewriter.Cli.slnx
+
+      - name: Build
+        run: dotnet build Typewriter.Cli.slnx -c Release --no-restore
+
+      - name: Test
+        run: dotnet test Typewriter.Cli.slnx -c Release --no-build
+
+      - name: Pack
+        run: dotnet pack src/Typewriter.Cli/Typewriter.Cli.csproj -c Release -o ./artifacts/nupkg --no-build
+
+      - name: Upload NuGet artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg
+          path: ./artifacts/nupkg/*.nupkg
+
+  parity-gate:
+    needs: build-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore Typewriter.Cli.slnx
+
+      - name: Build
+        run: dotnet build Typewriter.Cli.slnx -c Release --no-restore
+
+      - name: Run golden parity tests
+        run: dotnet test tests/Typewriter.GoldenTests/ -c Release --no-build
+
+  publish:
+    needs: [build-test, parity-gate]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download NuGet artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nupkg
+          path: ./artifacts/nupkg
+
+      - name: Publish to NuGet
+        run: dotnet nuget push ./artifacts/nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — a tag-triggered release workflow for publishing to NuGet
- **`build-test`** job: cross-platform matrix (windows/ubuntu/macos) running restore, build, test, and pack; uploads nupkg artifact from ubuntu runner
- **`parity-gate`** job: runs golden parity tests (`tests/Typewriter.GoldenTests/`) after `build-test` succeeds
- **`publish`** job: downloads nupkg artifact and pushes to NuGet using `NUGET_API_KEY` secret; depends on both `build-test` and `parity-gate`

Triggered only on `v*.*.*` tag pushes — no branch or PR triggers.

Closes #171

## Test plan
- [x] YAML syntax validated
- [x] Trigger: only `push: tags: ['v*.*.*']` — no branch/PR triggers
- [x] `parity-gate` depends on `build-test`; `publish` depends on both
- [x] `NUGET_API_KEY` read from `secrets` — never hardcoded
- [x] Steps match existing `ci.yml` patterns (restore, build, test, pack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)