### PR TITLE
feat: integrate InvocationCache into Compiler and RoslynWorkspaceService (M9, #178)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-05 by Claude (Executor, #176)
+> Last touched: 2026-03-05 by Claude (Executor, #178)
 
 ## Current State
 
@@ -117,6 +117,7 @@
 | #172 Verify release dry-run locally (M8) | M8 | Executor | Done | [T172-verify-release-dryrun.md](.ai/tasks/T172-verify-release-dryrun.md) — `dotnet pack` → local tool install → `typewriter-cli generate` smoke test all pass; reusable script `eng/verify-release-dryrun.sh` created; 179/179 tests pass |
 | #173 Run M8 acceptance criteria - CI matrix (M8) | M8 | Executor | Done | All M8 gates verified: CI matrix (3 OSes), smoke test, parity-gate→publish ordering, NUGET_API_KEY secret-only, release dry-run; 179/179 tests; `dotnet pack` produces versioned .nupkg; M8→Done, active→M9 |
 | #176 Create large-solution fixture generator | M9 | Executor | Done | `tests/fixtures/large-solution/` — 25 projects (Project01–Project25), LargeSolution.sln, generate.sh + generate.ps1; 5 .tst templates across Project03/07/12/18/22; dotnet restore verified; 179/179 tests pass |
+| #178 Integrate InvocationCache into Compiler and RoslynWorkspaceService | M9 | Executor | Done | `InvocationCache` moved to `Typewriter.Generation.Performance`; `Compiler` made non-static with cache injection (template Assembly caching); `RoslynWorkspaceService` caches Roslyn `Compilation` per project path; `InvocationCache` shared via `Program.cs` composition root → `ApplicationRunner` → `Compiler`; all 179/179 tests pass |
 
 ## Decisions
 

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -4,6 +4,7 @@ using Typewriter.CodeModel.Configuration;
 using Typewriter.CodeModel.Implementation;
 using Typewriter.Generation;
 using Typewriter.Generation.Output;
+using Typewriter.Generation.Performance;
 using Typewriter.Metadata.Roslyn;
 
 namespace Typewriter.Application;
@@ -19,6 +20,7 @@ public sealed class ApplicationRunner
     private readonly IRoslynWorkspaceService _roslynWorkspaceService;
     private readonly IOutputWriter _outputWriter;
     private readonly IOutputPathPolicy _outputPathPolicy;
+    private readonly InvocationCache _cache;
 
     /// <summary>
     /// Initializes a new <see cref="ApplicationRunner"/> with the required loading and generation services.
@@ -29,13 +31,19 @@ public sealed class ApplicationRunner
     /// <param name="roslynWorkspaceService">Opens projects in a Roslyn workspace and returns compilations.</param>
     /// <param name="outputWriter">Writer for persisting generated output to disk.</param>
     /// <param name="outputPathPolicy">Policy for resolving output paths with collision avoidance.</param>
+    /// <param name="cache">
+    /// Per-invocation cache for compiled template assemblies and Roslyn compilations.
+    /// Shared with <see cref="RoslynWorkspaceService"/> and <see cref="Compiler"/> to avoid
+    /// redundant work on repeated calls within the same process.
+    /// </param>
     public ApplicationRunner(
         IInputResolver inputResolver,
         IRestoreService restoreService,
         IProjectGraphService projectGraphService,
         IRoslynWorkspaceService roslynWorkspaceService,
         IOutputWriter outputWriter,
-        IOutputPathPolicy outputPathPolicy)
+        IOutputPathPolicy outputPathPolicy,
+        InvocationCache cache)
     {
         _inputResolver = inputResolver;
         _restoreService = restoreService;
@@ -43,6 +51,7 @@ public sealed class ApplicationRunner
         _roslynWorkspaceService = roslynWorkspaceService;
         _outputWriter = outputWriter;
         _outputPathPolicy = outputPathPolicy;
+        _cache = cache;
     }
 
     /// <summary>
@@ -136,6 +145,7 @@ public sealed class ApplicationRunner
         // 8. Execute templates against loaded metadata.
         var metadataProvider = new RoslynMetadataProvider(workspaceResult);
         var solutionFullName = resolvedInput.SolutionDirectory ?? resolvedInput.ProjectPath;
+        var compiler = new Compiler(_cache);
         var hasGenerationErrors = false;
 
         foreach (var templatePath in options.Templates)
@@ -156,6 +166,7 @@ public sealed class ApplicationRunner
                     solutionFullName,
                     _outputPathPolicy,
                     _outputWriter,
+                    compiler,
                     error =>
                     {
                         reporter.Report(new DiagnosticMessage(

--- a/src/Typewriter.Cli/Program.cs
+++ b/src/Typewriter.Cli/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine.Parsing;
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
 using Typewriter.Generation.Output;
+using Typewriter.Generation.Performance;
 using Typewriter.Loading.MSBuild;
 
 var rootCommand = new RootCommand("typewriter-cli \u2014 standalone Typewriter code generator");
@@ -57,16 +58,17 @@ generateCommand.SetHandler(async (InvocationContext ctx) =>
     var reporter = new MsBuildDiagnosticReporter();
 
     // Compose the loading pipeline services.
+    var cache = new InvocationCache();
     var locatorService = new MsBuildLocatorService();
     var inputResolver = new InputResolver();
     var restoreService = new RestoreService();
     var solutionFallbackService = new SolutionFallbackService();
     var projectGraphService = new ProjectGraphService(locatorService, solutionFallbackService);
-    var roslynWorkspaceService = new RoslynWorkspaceService();
+    var roslynWorkspaceService = new RoslynWorkspaceService(cache);
 
     var outputWriter = new OutputWriter();
     var outputPathPolicy = new OutputPathPolicy();
-    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService, roslynWorkspaceService, outputWriter, outputPathPolicy);
+    var runner = new ApplicationRunner(inputResolver, restoreService, projectGraphService, roslynWorkspaceService, outputWriter, outputPathPolicy, cache);
     ctx.ExitCode = await runner.RunAsync(options, reporter, ctx.GetCancellationToken());
 });
 

--- a/src/Typewriter.Generation/Compiler.cs
+++ b/src/Typewriter.Generation/Compiler.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.CodeAnalysis;
+using Typewriter.Generation.Performance;
 
 namespace Typewriter.Generation;
 
@@ -11,103 +12,124 @@ namespace Typewriter.Generation;
 ///   <item><c>Assembly.LoadFrom</c> replaced with <see cref="TemplateAssemblyLoadContext"/>.</item>
 ///   <item><c>ErrorList</c> / <c>Log</c> (VS OutputWindow) removed; diagnostics are surfaced
 ///         via the exception message on compilation failure.</item>
+///   <item>Per-invocation caching via <see cref="InvocationCache"/> skips Roslyn compilation on
+///         repeated calls with the same template path.</item>
 /// </list>
 /// Roslyn <see cref="Microsoft.CodeAnalysis.CSharp.CSharpCompilation"/> logic is preserved
 /// in <see cref="ShadowClass.Compile(string)"/>.
 /// </summary>
-internal static class Compiler
+public sealed class Compiler
 {
     private static readonly string TempDirectory = Path.Combine(Path.GetTempPath(), "Typewriter");
+
+    private readonly InvocationCache _cache;
+
+    /// <summary>
+    /// Initializes a new <see cref="Compiler"/> with the specified invocation cache.
+    /// </summary>
+    /// <param name="cache">
+    /// The per-invocation cache used to store compiled template assemblies, keyed by
+    /// normalized absolute template path.
+    /// </param>
+    public Compiler(InvocationCache cache)
+    {
+        _cache = cache;
+    }
 
     /// <summary>
     /// Compiles the shadow class and returns the generated <c>__Typewriter.Template</c> type,
     /// loaded in an isolated <see cref="TemplateAssemblyLoadContext"/>.
+    /// On repeated calls with the same <paramref name="templateFilePath"/>, the cached assembly
+    /// is returned without invoking Roslyn compilation.
     /// </summary>
     /// <param name="templateFilePath">Absolute path to the <c>.tst</c> template file.</param>
     /// <param name="shadowClass">The shadow class containing parsed template code.</param>
     /// <returns>The compiled template <see cref="Type"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when compilation produces errors.</exception>
-    public static Type Compile(string templateFilePath, ShadowClass shadowClass)
+    public Type Compile(string templateFilePath, ShadowClass shadowClass)
     {
-        if (!Directory.Exists(TempDirectory))
+        var assembly = _cache.GetOrAddTemplate(templateFilePath, _ =>
         {
-            Directory.CreateDirectory(TempDirectory);
-        }
-
-        // Copy referenced assemblies to the temp directory so the isolated load context
-        // can resolve them at runtime.
-        foreach (var assembly in shadowClass.ReferencedAssemblies)
-        {
-            var asmSourcePath = assembly.Location;
-            if (string.IsNullOrEmpty(asmSourcePath))
+            if (!Directory.Exists(TempDirectory))
             {
-                continue;
+                Directory.CreateDirectory(TempDirectory);
             }
 
-            var asmDestPath = Path.Combine(TempDirectory, Path.GetFileName(asmSourcePath));
-
-            var sourceAssemblyName = AssemblyName.GetAssemblyName(asmSourcePath);
-
-            // Skip the copy if the destination already has the same version.
-            if (File.Exists(asmDestPath))
+            // Copy referenced assemblies to the temp directory so the isolated load context
+            // can resolve them at runtime.
+            foreach (var refAsm in shadowClass.ReferencedAssemblies)
             {
-                var destAssemblyName = AssemblyName.GetAssemblyName(asmDestPath);
-                if (sourceAssemblyName.Version is not null
-                    && destAssemblyName.Version is not null
-                    && sourceAssemblyName.Version.CompareTo(destAssemblyName.Version) == 0)
+                var asmSourcePath = refAsm.Location;
+                if (string.IsNullOrEmpty(asmSourcePath))
                 {
                     continue;
                 }
+
+                var asmDestPath = Path.Combine(TempDirectory, Path.GetFileName(asmSourcePath));
+
+                var sourceAssemblyName = AssemblyName.GetAssemblyName(asmSourcePath);
+
+                // Skip the copy if the destination already has the same version.
+                if (File.Exists(asmDestPath))
+                {
+                    var destAssemblyName = AssemblyName.GetAssemblyName(asmDestPath);
+                    if (sourceAssemblyName.Version is not null
+                        && destAssemblyName.Version is not null
+                        && sourceAssemblyName.Version.CompareTo(destAssemblyName.Version) == 0)
+                    {
+                        continue;
+                    }
+                }
+
+                try
+                {
+                    File.Copy(asmSourcePath, asmDestPath, overwrite: true);
+                }
+                catch (IOException)
+                {
+                    // File may be in use by another template compilation; non-fatal.
+                }
             }
 
-            try
+            var fileName = Path.GetRandomFileName();
+            var path = Path.Combine(TempDirectory, fileName);
+
+            var result = shadowClass.Compile(path);
+
+            var errors = result.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error
+                         || d.Severity == DiagnosticSeverity.Warning);
+
+            var hasErrors = false;
+            var errorMessages = new List<string>();
+
+            foreach (var diagnostic in errors)
             {
-                File.Copy(asmSourcePath, asmDestPath, overwrite: true);
+                var message = diagnostic.GetMessage();
+                message = message.Replace("__Typewriter.", string.Empty);
+                message = message.Replace("publicstatic", string.Empty);
+
+                if (diagnostic.Severity == DiagnosticSeverity.Error || diagnostic.IsWarningAsError)
+                {
+                    hasErrors = true;
+                    errorMessages.Add($"error {diagnostic.Id}: {message}");
+                }
             }
-            catch (IOException)
+
+            if (result.Success && !hasErrors)
             {
-                // File may be in use by another template compilation; non-fatal.
+                var assemblyDir = Path.GetDirectoryName(path)!;
+                var loadContext = new TemplateAssemblyLoadContext(assemblyDir);
+                return loadContext.LoadFromAssemblyPath(path);
             }
-        }
 
-        var fileName = Path.GetRandomFileName();
-        var path = Path.Combine(TempDirectory, fileName);
+            throw new InvalidOperationException(
+                $"Failed to compile template '{templateFilePath}'. Errors:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, errorMessages));
+        });
 
-        var result = shadowClass.Compile(path);
-
-        var errors = result.Diagnostics
-            .Where(d => d.Severity == DiagnosticSeverity.Error
-                     || d.Severity == DiagnosticSeverity.Warning);
-
-        var hasErrors = false;
-        var errorMessages = new List<string>();
-
-        foreach (var diagnostic in errors)
-        {
-            var message = diagnostic.GetMessage();
-            message = message.Replace("__Typewriter.", string.Empty);
-            message = message.Replace("publicstatic", string.Empty);
-
-            if (diagnostic.Severity == DiagnosticSeverity.Error || diagnostic.IsWarningAsError)
-            {
-                hasErrors = true;
-                errorMessages.Add($"error {diagnostic.Id}: {message}");
-            }
-        }
-
-        if (result.Success && !hasErrors)
-        {
-            var assemblyDir = Path.GetDirectoryName(path)!;
-            var loadContext = new TemplateAssemblyLoadContext(assemblyDir);
-            var assembly = loadContext.LoadFromAssemblyPath(path);
-            var type = assembly.GetType("__Typewriter.Template");
-
-            return type ?? throw new InvalidOperationException(
-                $"Compiled assembly does not contain the expected type '__Typewriter.Template'. Template: {templateFilePath}");
-        }
-
-        throw new InvalidOperationException(
-            $"Failed to compile template '{templateFilePath}'. Errors:{Environment.NewLine}"
-            + string.Join(Environment.NewLine, errorMessages));
+        var type = assembly.GetType("__Typewriter.Template");
+        return type ?? throw new InvalidOperationException(
+            $"Compiled assembly does not contain the expected type '__Typewriter.Template'. Template: {templateFilePath}");
     }
 }

--- a/src/Typewriter.Generation/Performance/InvocationCache.cs
+++ b/src/Typewriter.Generation/Performance/InvocationCache.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
-namespace Typewriter.Application.Performance;
+namespace Typewriter.Generation.Performance;
 
 /// <summary>
 /// Per-invocation, memory-only cache for compiled template assemblies and Roslyn

--- a/src/Typewriter.Generation/Template.cs
+++ b/src/Typewriter.Generation/Template.cs
@@ -30,6 +30,7 @@ public class Template
     private readonly string _solutionFullName;
     private readonly IOutputPathPolicy _outputPathPolicy;
     private readonly IOutputWriter _outputWriter;
+    private readonly Compiler _compiler;
     private readonly Action<string>? _errorReporter;
     private Lazy<string?> _template;
     private Lazy<SettingsImpl> _configuration;
@@ -58,18 +59,24 @@ public class Template
     /// <param name="solutionFullName">Absolute path to the solution or project file.</param>
     /// <param name="outputPathPolicy">Policy for resolving output paths with collision avoidance.</param>
     /// <param name="outputWriter">Writer for persisting generated output to disk.</param>
+    /// <param name="compiler">
+    /// The <see cref="Compiler"/> instance used for template compilation, with per-invocation
+    /// caching via <see cref="Performance.InvocationCache"/>.
+    /// </param>
     /// <param name="errorReporter">Optional callback invoked with diagnostic messages on errors.</param>
     public Template(
         string templatePath,
         string solutionFullName,
         IOutputPathPolicy outputPathPolicy,
         IOutputWriter outputWriter,
+        Compiler compiler,
         Action<string>? errorReporter = null)
     {
         _templatePath = templatePath;
         _solutionFullName = solutionFullName;
         _outputPathPolicy = outputPathPolicy;
         _outputWriter = outputWriter;
+        _compiler = compiler;
         _errorReporter = errorReporter;
         _template = LazyTemplate();
         _configuration = LazyConfiguration();
@@ -272,7 +279,7 @@ public class Template
             var code = System.IO.File.ReadAllText(_templatePath);
             try
             {
-                var result = TemplateCodeParser.Parse(_templatePath, code, _customExtensions);
+                var result = TemplateCodeParser.Parse(_templatePath, code, _customExtensions, _compiler);
                 _templateCompiled = true;
                 return result;
             }

--- a/src/Typewriter.Generation/TemplateCodeParser.cs
+++ b/src/Typewriter.Generation/TemplateCodeParser.cs
@@ -23,8 +23,13 @@ public static class TemplateCodeParser
     /// <param name="templateFilePath">Absolute path to the <c>.tst</c> template file.</param>
     /// <param name="template">The raw template content.</param>
     /// <param name="extensions">List populated with compiled extension types.</param>
+    /// <param name="compiler">
+    /// The <see cref="Compiler"/> instance used to compile the parsed shadow class.
+    /// Uses <see cref="Performance.InvocationCache"/> internally to skip recompilation on
+    /// repeated calls with the same template path.
+    /// </param>
     /// <returns>The processed template output, or <c>null</c> if the template is empty.</returns>
-    public static string? Parse(string templateFilePath, string template, List<Type> extensions)
+    public static string? Parse(string templateFilePath, string template, List<Type> extensions, Compiler compiler)
     {
         if (string.IsNullOrWhiteSpace(template))
         {
@@ -61,7 +66,7 @@ public static class TemplateCodeParser
         shadowClass.Parse();
 
         extensions.Clear();
-        extensions.Add(Compiler.Compile(templateFilePath, shadowClass));
+        extensions.Add(compiler.Compile(templateFilePath, shadowClass));
         extensions.AddRange(FindExtensionClasses(shadowClass));
 
         return output;

--- a/src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs
+++ b/src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
 using Typewriter.Application.Orchestration;
+using Typewriter.Generation.Performance;
 using Typewriter.Metadata.Roslyn;
 
 using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
@@ -16,8 +17,27 @@ namespace Typewriter.Loading.MSBuild;
 /// MSBuild registration must be completed by <see cref="IMsBuildLocatorService"/> before
 /// calling <see cref="LoadAsync"/>.
 /// </summary>
+/// <remarks>
+/// Uses <see cref="InvocationCache"/> to cache Roslyn <see cref="Compilation"/> objects
+/// per project path, avoiding redundant compilation on repeated invocations within the
+/// same process.
+/// </remarks>
 public sealed class RoslynWorkspaceService : IRoslynWorkspaceService
 {
+    private readonly InvocationCache _cache;
+
+    /// <summary>
+    /// Initializes a new <see cref="RoslynWorkspaceService"/> with the specified invocation cache.
+    /// </summary>
+    /// <param name="cache">
+    /// The per-invocation cache used to store Roslyn compilations, keyed by normalized
+    /// absolute project path.
+    /// </param>
+    public RoslynWorkspaceService(InvocationCache cache)
+    {
+        _cache = cache;
+    }
+
     /// <inheritdoc />
     /// <remarks>
     /// Creates a single <see cref="MSBuildWorkspace"/> for the entire plan, opens each
@@ -89,7 +109,10 @@ public sealed class RoslynWorkspaceService : IRoslynWorkspaceService
             Compilation? compilation;
             try
             {
-                compilation = await project.GetCompilationAsync(ct);
+                compilation = _cache.GetOrAddCompilation(loadTarget.ProjectPath, _ =>
+                    project.GetCompilationAsync(ct).GetAwaiter().GetResult()
+                    ?? throw new InvalidOperationException(
+                        $"Compilation was null for project '{loadTarget.ProjectName}'."));
             }
             catch (Exception ex)
             {
@@ -97,16 +120,6 @@ public sealed class RoslynWorkspaceService : IRoslynWorkspaceService
                     TwDiagnosticSeverity.Error,
                     DiagnosticCode.TW2202,
                     $"Compilation failed for project '{loadTarget.ProjectName}': {ex.Message}",
-                    File: loadTarget.ProjectPath));
-                continue;
-            }
-
-            if (compilation is null)
-            {
-                reporter.Report(new DiagnosticMessage(
-                    TwDiagnosticSeverity.Error,
-                    DiagnosticCode.TW2202,
-                    $"Compilation was null for project '{loadTarget.ProjectName}'.",
                     File: loadTarget.ProjectPath));
                 continue;
             }

--- a/tests/Typewriter.GoldenTests/Infrastructure/GoldenTestBase.cs
+++ b/tests/Typewriter.GoldenTests/Infrastructure/GoldenTestBase.cs
@@ -1,6 +1,7 @@
 using Typewriter.Application;
 using Typewriter.Application.Diagnostics;
 using Typewriter.Generation.Output;
+using Typewriter.Generation.Performance;
 using Typewriter.Loading.MSBuild;
 using Xunit;
 
@@ -76,11 +77,12 @@ public abstract class GoldenTestBase : IAsyncLifetime
         var reporter = new TestDiagnosticReporter();
         var capturingWriter = new CapturingOutputWriter();
 
+        var cache = new InvocationCache();
         var inputResolver = new InputResolver();
         var restoreService = new RestoreService();
         var solutionFallbackService = new SolutionFallbackService();
         var projectGraphService = new ProjectGraphService(Locator, solutionFallbackService);
-        var roslynWorkspaceService = new RoslynWorkspaceService();
+        var roslynWorkspaceService = new RoslynWorkspaceService(cache);
         var outputPathPolicy = new OutputPathPolicy();
 
         var runner = new ApplicationRunner(
@@ -89,7 +91,8 @@ public abstract class GoldenTestBase : IAsyncLifetime
             projectGraphService,
             roslynWorkspaceService,
             capturingWriter,
-            outputPathPolicy);
+            outputPathPolicy,
+            cache);
 
         var options = new GenerateCommandOptions(
             Templates: templatePaths,

--- a/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
+++ b/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
@@ -5,6 +5,7 @@ using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
 using Typewriter.Application.Orchestration;
 using Typewriter.Generation.Output;
+using Typewriter.Generation.Performance;
 using Typewriter.Metadata.Roslyn;
 using Xunit;
 
@@ -132,7 +133,8 @@ public class CliContractTests : IDisposable
             new StubProjectGraphService(),
             new StubRoslynWorkspaceService(),
             new StubOutputWriter(),
-            new StubOutputPathPolicy());
+            new StubOutputPathPolicy(),
+            new InvocationCache());
 
     [Fact]
     public async Task Generate_InvalidArgs_Returns2()

--- a/tests/Typewriter.UnitTests/Generation/TemplateEngineTests.cs
+++ b/tests/Typewriter.UnitTests/Generation/TemplateEngineTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using Typewriter.CodeModel.Configuration;
 using Typewriter.CodeModel.Implementation;
 using Typewriter.Generation;
+using Typewriter.Generation.Performance;
 using Typewriter.Metadata;
 using Xunit;
 using File = System.IO.File;
@@ -74,9 +75,10 @@ public class TemplateEngineTests : IDisposable
         var templateContent = $"#reference {metadataDllName}\n#reference {generationDllName}\n";
 
         var extensions = new List<Type>();
+        var compiler = new Compiler(new InvocationCache());
 
         // Act
-        var result = TemplateCodeParser.Parse(templateFilePath, templateContent, extensions);
+        var result = TemplateCodeParser.Parse(templateFilePath, templateContent, extensions, compiler);
 
         // Assert — compilation succeeded and produced a type.
         Assert.NotEmpty(extensions);
@@ -201,8 +203,9 @@ public class TemplateEngineTests : IDisposable
             "tests", "fixtures", "simple", "SimpleProject", "Interfaces.tst"));
         var templateContent = File.ReadAllText(templatePath);
         var extensions = new List<Type>();
+        var compiler = new Compiler(new InvocationCache());
 
-        var result = TemplateCodeParser.Parse(templatePath, templateContent, extensions);
+        var result = TemplateCodeParser.Parse(templatePath, templateContent, extensions, compiler);
 
         Assert.NotNull(result);
         Assert.NotEmpty(extensions);
@@ -220,8 +223,9 @@ public class TemplateEngineTests : IDisposable
             "tests", "fixtures", "simple", "SimpleProject", "Enums.tst"));
         var templateContent = File.ReadAllText(templatePath);
         var extensions = new List<Type>();
+        var compiler = new Compiler(new InvocationCache());
 
-        var result = TemplateCodeParser.Parse(templatePath, templateContent, extensions);
+        var result = TemplateCodeParser.Parse(templatePath, templateContent, extensions, compiler);
 
         Assert.NotNull(result);
         Assert.NotEmpty(extensions);

--- a/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
+++ b/tests/Typewriter.UnitTests/Loading/ProjectLoaderTests.cs
@@ -6,6 +6,7 @@ using Typewriter.Application.Diagnostics;
 using Typewriter.Application.Loading;
 using Typewriter.Application.Orchestration;
 using Typewriter.Generation.Output;
+using Typewriter.Generation.Performance;
 using Typewriter.Metadata.Roslyn;
 using Xunit;
 
@@ -80,7 +81,7 @@ public class ProjectLoaderTests : IDisposable
             .LoadAsync(Arg.Any<ProjectLoadPlan>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult([])));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>());
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>(), new InvocationCache());
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
@@ -110,7 +111,7 @@ public class ProjectLoaderTests : IDisposable
             .CheckAssetsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>());
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>(), new InvocationCache());
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: false), reporter);
@@ -156,7 +157,7 @@ public class ProjectLoaderTests : IDisposable
             .LoadAsync(Arg.Any<ProjectLoadPlan>(), Arg.Any<IDiagnosticReporter>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkspaceLoadResult?>(new WorkspaceLoadResult([])));
 
-        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>());
+        var runner = new ApplicationRunner(inputResolver, restoreService, graphService, roslynWorkspaceService, Substitute.For<IOutputWriter>(), Substitute.For<IOutputPathPolicy>(), new InvocationCache());
 
         // Act
         var exitCode = await runner.RunAsync(MakeOptions(restore: true), reporter);


### PR DESCRIPTION
## Summary
- Moved `InvocationCache` from `Typewriter.Application.Performance` to `Typewriter.Generation.Performance` to avoid circular dependency (Application → Generation)
- Made `Compiler` non-static with constructor-injected `InvocationCache`; wraps compilation in `GetOrAddTemplate()` so second call with same template path returns cached `Assembly` without invoking Roslyn
- Injected `InvocationCache` into `RoslynWorkspaceService` constructor; wraps `GetCompilationAsync` in `GetOrAddCompilation()` so repeated project compilations are cached
- Shared single `InvocationCache` instance via `Program.cs` composition root → both `RoslynWorkspaceService` and `ApplicationRunner` (→ `Compiler`)
- Updated `TemplateCodeParser.Parse` and `Template` constructor to accept `Compiler` instance

## Test plan
- [x] `dotnet build -c Release` succeeds (0 errors)
- [x] `dotnet test -c Release` passes all 179/179 tests (159 unit + 13 integration + 6 golden + 1 perf)
- [x] All existing test call sites updated to pass `InvocationCache`/`Compiler` instances

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)