### PR TITLE
feat: enforce AGENTS.md §11 constraints in cache integration (M9, #179)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-05 by Claude (Executor, #178)
+> Last touched: 2026-03-05 by Claude (Executor, #179)
 
 ## Current State
 
@@ -118,6 +118,7 @@
 | #173 Run M8 acceptance criteria - CI matrix (M8) | M8 | Executor | Done | All M8 gates verified: CI matrix (3 OSes), smoke test, parity-gate→publish ordering, NUGET_API_KEY secret-only, release dry-run; 179/179 tests; `dotnet pack` produces versioned .nupkg; M8→Done, active→M9 |
 | #176 Create large-solution fixture generator | M9 | Executor | Done | `tests/fixtures/large-solution/` — 25 projects (Project01–Project25), LargeSolution.sln, generate.sh + generate.ps1; 5 .tst templates across Project03/07/12/18/22; dotnet restore verified; 179/179 tests pass |
 | #178 Integrate InvocationCache into Compiler and RoslynWorkspaceService | M9 | Executor | Done | `InvocationCache` moved to `Typewriter.Generation.Performance`; `Compiler` made non-static with cache injection (template Assembly caching); `RoslynWorkspaceService` caches Roslyn `Compilation` per project path; `InvocationCache` shared via `Program.cs` composition root → `ApplicationRunner` → `Compiler`; all 179/179 tests pass |
+| #179 Enforce AGENTS.md §11 constraints in cache integration | M9 | Executor | Done | Scope isolation: `InvocationCache.SetScope()` prefixes compilation keys with entry-point path; single workspace guard: `Interlocked.CompareExchange` in `RoslynWorkspaceService.LoadAsync`; MSBuild single-pass verified clean; 4 new unit tests (`InvocationCacheTests`); all 183/183 tests pass |
 
 ## Decisions
 

--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -94,6 +94,11 @@ public sealed class ApplicationRunner
         if (resolvedInput is null)
             return 2;
 
+        // Bind the cache scope to the resolved entry-point so that compilation cache keys
+        // include the scope and cannot be served to a different --project/--solution run
+        // (AGENTS.md §11.1 — scope isolation).
+        _cache.SetScope(resolvedInput.ProjectPath);
+
         // 4. Check restore assets; run restore if requested.
         var assetsPresent = await _restoreService.CheckAssetsAsync(resolvedInput.ProjectPath, cancellationToken);
         if (!assetsPresent)

--- a/src/Typewriter.Generation/Performance/InvocationCache.cs
+++ b/src/Typewriter.Generation/Performance/InvocationCache.cs
@@ -9,14 +9,23 @@ namespace Typewriter.Generation.Performance;
 /// <see cref="Compilation"/> objects. Scoped to a single process lifetime.
 /// </summary>
 /// <remarks>
+/// <para>
 /// All keys are normalized to absolute paths via <see cref="Path.GetFullPath(string)"/>
 /// to ensure consistent cache hits regardless of relative-path variations.
 /// This class uses instance-level state only (no static mutable state).
+/// </para>
+/// <para>
+/// Compilation cache keys include an optional scope prefix set via <see cref="SetScope"/>.
+/// When <c>--project</c> is used, the scope is set to the resolved project path so that
+/// compilations cached under one scope are never served to a different scope
+/// (AGENTS.md §11.1 — scope isolation).
+/// </para>
 /// </remarks>
 public sealed class InvocationCache
 {
     private readonly ConcurrentDictionary<string, Assembly> _templateAssemblies = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, Compilation> _compilations = new(StringComparer.OrdinalIgnoreCase);
+    private string? _scope;
 
     /// <summary>
     /// Gets the cached template assemblies, keyed by absolute template file path.
@@ -24,9 +33,21 @@ public sealed class InvocationCache
     public ConcurrentDictionary<string, Assembly> TemplateAssemblies => _templateAssemblies;
 
     /// <summary>
-    /// Gets the cached Roslyn compilations, keyed by absolute project file path.
+    /// Gets the cached Roslyn compilations, keyed by scope-prefixed absolute project file path.
     /// </summary>
     public ConcurrentDictionary<string, Compilation> Compilations => _compilations;
+
+    /// <summary>
+    /// Sets the scope prefix used for compilation cache keys. Must be called before any
+    /// <see cref="GetOrAddCompilation"/> call. Subsequent calls are ignored (first-write wins).
+    /// </summary>
+    /// <param name="scope">
+    /// The resolved entry-point path (project or solution). Normalized to an absolute path.
+    /// </param>
+    public void SetScope(string scope)
+    {
+        Interlocked.CompareExchange(ref _scope, Path.GetFullPath(scope), null);
+    }
 
     /// <summary>
     /// Returns the cached <see cref="Assembly"/> for the given template path, or invokes
@@ -48,6 +69,8 @@ public sealed class InvocationCache
     /// <summary>
     /// Returns the cached <see cref="Compilation"/> for the given project path, or invokes
     /// <paramref name="factory"/> to produce and cache one.
+    /// The cache key includes the scope prefix set via <see cref="SetScope"/> to prevent
+    /// cross-scope pollution (AGENTS.md §11.1).
     /// </summary>
     /// <param name="projectPath">
     /// The project file path. Normalized to an absolute path via <see cref="Path.GetFullPath(string)"/>.
@@ -58,7 +81,8 @@ public sealed class InvocationCache
     /// <returns>The cached or newly created <see cref="Compilation"/>.</returns>
     public Compilation GetOrAddCompilation(string projectPath, Func<string, Compilation> factory)
     {
-        var key = Path.GetFullPath(projectPath);
-        return _compilations.GetOrAdd(key, factory);
+        var normalizedPath = Path.GetFullPath(projectPath);
+        var key = _scope != null ? $"{_scope}|{normalizedPath}" : normalizedPath;
+        return _compilations.GetOrAdd(key, _ => factory(normalizedPath));
     }
 }

--- a/src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs
+++ b/src/Typewriter.Loading.MSBuild/RoslynWorkspaceService.cs
@@ -25,6 +25,7 @@ namespace Typewriter.Loading.MSBuild;
 public sealed class RoslynWorkspaceService : IRoslynWorkspaceService
 {
     private readonly InvocationCache _cache;
+    private int _workspaceCreated;
 
     /// <summary>
     /// Initializes a new <see cref="RoslynWorkspaceService"/> with the specified invocation cache.
@@ -52,6 +53,14 @@ public sealed class RoslynWorkspaceService : IRoslynWorkspaceService
         IDiagnosticReporter reporter,
         CancellationToken ct)
     {
+        // Guard: at most one MSBuildWorkspace per invocation (AGENTS.md §11.2).
+        if (Interlocked.CompareExchange(ref _workspaceCreated, 1, 0) != 0)
+        {
+            throw new InvalidOperationException(
+                "An MSBuildWorkspace has already been created for this invocation. " +
+                "RoslynWorkspaceService.LoadAsync must not be called more than once.");
+        }
+
         var properties = new Dictionary<string, string>(plan.GlobalProperties);
 
         MSBuildWorkspace workspace;

--- a/tests/Typewriter.UnitTests/Performance/InvocationCacheTests.cs
+++ b/tests/Typewriter.UnitTests/Performance/InvocationCacheTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Typewriter.Generation.Performance;
+using Xunit;
+
+namespace Typewriter.UnitTests.Performance;
+
+public class InvocationCacheTests
+{
+    /// <summary>
+    /// Verifies that compilations cached under different scopes do not collide,
+    /// even when the underlying project path is identical (AGENTS.md §11.1).
+    /// </summary>
+    [Fact]
+    public void GetOrAddCompilation_DifferentScopes_DoNotCollide()
+    {
+        // Arrange — two caches with different scopes pointing at the same project.
+        var cacheA = new InvocationCache();
+        cacheA.SetScope("/solutions/A.sln");
+
+        var cacheB = new InvocationCache();
+        cacheB.SetScope("/solutions/B.sln");
+
+        var compilationA = CSharpCompilation.Create("A");
+        var compilationB = CSharpCompilation.Create("B");
+
+        const string projectPath = "/projects/Shared.csproj";
+
+        // Act
+        var resultA = cacheA.GetOrAddCompilation(projectPath, _ => compilationA);
+        var resultB = cacheB.GetOrAddCompilation(projectPath, _ => compilationB);
+
+        // Assert — each scope returns its own compilation.
+        Assert.Same(compilationA, resultA);
+        Assert.Same(compilationB, resultB);
+    }
+
+    /// <summary>
+    /// Verifies that repeated calls with the same scope and project path
+    /// return the cached compilation without invoking the factory again.
+    /// </summary>
+    [Fact]
+    public void GetOrAddCompilation_SameScope_ReturnsCachedValue()
+    {
+        var cache = new InvocationCache();
+        cache.SetScope("/solutions/A.sln");
+
+        var compilation = CSharpCompilation.Create("Cached");
+        var callCount = 0;
+
+        const string projectPath = "/projects/Lib.csproj";
+
+        var first = cache.GetOrAddCompilation(projectPath, _ =>
+        {
+            callCount++;
+            return compilation;
+        });
+
+        var second = cache.GetOrAddCompilation(projectPath, _ =>
+        {
+            callCount++;
+            return CSharpCompilation.Create("ShouldNotBeCreated");
+        });
+
+        Assert.Same(first, second);
+        Assert.Equal(1, callCount);
+    }
+
+    /// <summary>
+    /// Verifies that SetScope follows first-write-wins semantics.
+    /// A second call to SetScope does not change the scope.
+    /// </summary>
+    [Fact]
+    public void SetScope_CalledTwice_FirstWins()
+    {
+        var cache = new InvocationCache();
+        cache.SetScope("/scope/First.sln");
+        cache.SetScope("/scope/Second.sln");
+
+        var compilation = CSharpCompilation.Create("Test");
+        const string projectPath = "/projects/Lib.csproj";
+
+        cache.GetOrAddCompilation(projectPath, _ => compilation);
+
+        // The key should use the first scope. Verify by checking Compilations dictionary.
+        var firstScopeKey = Path.GetFullPath("/scope/First.sln") + "|" + Path.GetFullPath(projectPath);
+        var secondScopeKey = Path.GetFullPath("/scope/Second.sln") + "|" + Path.GetFullPath(projectPath);
+
+        Assert.True(cache.Compilations.ContainsKey(firstScopeKey));
+        Assert.False(cache.Compilations.ContainsKey(secondScopeKey));
+    }
+
+    /// <summary>
+    /// Verifies that template assembly caching is unaffected by scope
+    /// (templates are scope-independent).
+    /// </summary>
+    [Fact]
+    public void GetOrAddTemplate_IgnoresScope()
+    {
+        var cache = new InvocationCache();
+        cache.SetScope("/scope/A.sln");
+
+        var callCount = 0;
+        const string templatePath = "/templates/Test.tst";
+
+        var first = cache.GetOrAddTemplate(templatePath, _ =>
+        {
+            callCount++;
+            return typeof(string).Assembly;
+        });
+
+        var second = cache.GetOrAddTemplate(templatePath, _ =>
+        {
+            callCount++;
+            return typeof(int).Assembly;
+        });
+
+        Assert.Same(first, second);
+        Assert.Equal(1, callCount);
+    }
+}


### PR DESCRIPTION
## Summary

- **Scope isolation**: `InvocationCache.SetScope()` prefixes compilation cache keys with the resolved entry-point path, preventing `--project`-scoped invocations from serving compilations cached under a different scope (AGENTS.md §11.1)
- **Single workspace guard**: `RoslynWorkspaceService.LoadAsync` uses `Interlocked.CompareExchange` to ensure at most one `MSBuildWorkspace` is created per invocation (AGENTS.md §11.2)
- **MSBuild single-pass**: Verified that cache integration introduces no new MSBuild registration paths — `MsBuildLocatorService.EnsureRegistered()` remains the sole registration point with its existing one-shot guard (AGENTS.md §11.3)
- **Behavior parity**: All 183 tests pass (163 unit + 13 integration + 6 golden + 1 perf), confirming no regression (AGENTS.md §11.5)

Closes #179

## Test plan

- [x] 4 new `InvocationCacheTests`: scope isolation, cache hit, first-write-wins semantics, template independence
- [x] All existing integration tests pass: `dotnet test tests/Typewriter.IntegrationTests/ -c Release`
- [x] Full test suite passes: 183/183 (163 unit + 13 integration + 6 golden + 1 perf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)