### PR TITLE
docs: document performance budgets in PerformanceTests README (M9, #182)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-05 by Claude (Executor, #179)
+> Last touched: 2026-03-05 by Claude (Executor, #182)
 
 ## Current State
 
@@ -119,6 +119,7 @@
 | #176 Create large-solution fixture generator | M9 | Executor | Done | `tests/fixtures/large-solution/` — 25 projects (Project01–Project25), LargeSolution.sln, generate.sh + generate.ps1; 5 .tst templates across Project03/07/12/18/22; dotnet restore verified; 179/179 tests pass |
 | #178 Integrate InvocationCache into Compiler and RoslynWorkspaceService | M9 | Executor | Done | `InvocationCache` moved to `Typewriter.Generation.Performance`; `Compiler` made non-static with cache injection (template Assembly caching); `RoslynWorkspaceService` caches Roslyn `Compilation` per project path; `InvocationCache` shared via `Program.cs` composition root → `ApplicationRunner` → `Compiler`; all 179/179 tests pass |
 | #179 Enforce AGENTS.md §11 constraints in cache integration | M9 | Executor | Done | Scope isolation: `InvocationCache.SetScope()` prefixes compilation keys with entry-point path; single workspace guard: `Interlocked.CompareExchange` in `RoslynWorkspaceService.LoadAsync`; MSBuild single-pass verified clean; 4 new unit tests (`InvocationCacheTests`); all 183/183 tests pass |
+| #182 Document performance budgets in README.md | M9 | Executor | Done | `tests/Typewriter.PerformanceTests/README.md` — wall-time (60 s), memory (2 GB), run command, update process, fixture description |
 
 ## Decisions
 

--- a/tests/Typewriter.PerformanceTests/README.md
+++ b/tests/Typewriter.PerformanceTests/README.md
@@ -1,0 +1,68 @@
+# Performance Tests
+
+Performance acceptance tests for the typewriter-cli pipeline, enforcing time and memory budgets against a large-solution fixture.
+
+## Wall-Time Budget
+
+**60 seconds** on a GitHub-hosted `ubuntu-latest` runner.
+
+Rationale: the budget accounts for cold-start overhead (no warm NuGet/MSBuild caches) and the single-threaded Roslyn workspace load path. GitHub-hosted runners provide 2-core / 7 GB RAM machines; 60 s gives comfortable headroom over observed local times while catching genuine regressions.
+
+The assertion lives in `LargeSolutionTests.LargeSolution_CompletesUnderThreshold`:
+
+```csharp
+Assert.True(
+    stopwatch.Elapsed.TotalSeconds <= 60,
+    $"Pipeline took {stopwatch.Elapsed.TotalSeconds:F2} s, exceeding the 60 s budget.");
+```
+
+## Memory Budget
+
+**2 GB peak working set**.
+
+Rationale: GitHub-hosted `ubuntu-latest` runners provide 7 GB RAM. A 2 GB ceiling ensures the CLI leaves ample room for the OS, MSBuild, and other CI processes. It also matches the memory profile of a typical developer laptop running multiple applications.
+
+The assertion lives in `LargeSolutionTests.LargeSolution_PeakWorkingSet_UnderBudget`:
+
+```csharp
+Assert.True(
+    peakWorkingSet <= 2L * 1024 * 1024 * 1024,
+    $"Peak working set {peakWorkingSet / (1024.0 * 1024.0):F1} MB exceeds 2 GB budget.");
+```
+
+## How to Run
+
+```bash
+dotnet test tests/Typewriter.PerformanceTests/ -c Release --filter "Category=Performance"
+```
+
+Both tests are tagged with `[Trait("Category", "Performance")]`, so the filter selects them specifically. Run in `Release` configuration to measure representative performance.
+
+## How to Update Budgets
+
+1. Open `LargeSolutionTests.cs`.
+2. Update the `Assert.True` threshold values:
+   - Wall-time: change `60` in `LargeSolution_CompletesUnderThreshold`.
+   - Memory: change `2L * 1024 * 1024 * 1024` in `LargeSolution_PeakWorkingSet_UnderBudget`.
+3. Document the reason for the change in the commit message (e.g., new baseline after adding caching, accommodating a larger fixture).
+
+## Large-Solution Fixture
+
+The fixture lives at `tests/fixtures/large-solution/` and simulates a realistic multi-project solution:
+
+- **25 projects** (`Project01` through `Project25`), each with a minimal `.csproj` targeting `net10.0` and a single `Class1.cs`.
+- **1 solution file** (`LargeSolution.sln`) referencing all 25 projects with deterministic GUIDs.
+- **5 `.tst` templates** spread across selected projects:
+  - `Project03/Enums.tst` — enumerates enums.
+  - `Project07/Interfaces.tst` — generates interfaces from `*Model` classes.
+  - `Project12/Models.tst` — generates classes from all classes.
+  - `Project18/Services.tst` — generates interfaces from `*Service` interfaces.
+  - `Project22/AllTypes.tst` — lists all types (classes, interfaces, enums).
+
+### Regenerating the Fixture
+
+```bash
+bash tests/fixtures/large-solution/generate.sh
+```
+
+The script is idempotent: it deletes all generated content (preserving `generate.sh` and `generate.ps1`) before recreating the projects, templates, and solution file. A PowerShell equivalent (`generate.ps1`) is also available for Windows.


### PR DESCRIPTION
## Summary
- Create `tests/Typewriter.PerformanceTests/README.md` documenting all performance budgets and measurement methodology
- Wall-time budget: 60 s on GitHub-hosted ubuntu runner (cold start, no local caching)
- Memory budget: 2 GB peak working set (typical CI runner memory)
- Includes how-to-run command, budget update process, and large-solution fixture description with regeneration instructions

Closes #182

## Test plan
- [x] README.md exists with all 5 required sections
- [x] Wall-time and memory budgets explicitly stated with rationale
- [x] Run command is correct: `dotnet test tests/Typewriter.PerformanceTests/ -c Release --filter "Category=Performance"`
- [x] Budget update instructions reference correct assertion methods in `LargeSolutionTests.cs`
- [x] Large-solution fixture description matches `generate.sh` output (25 projects, 5 templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)