### PR TITLE
feat: add diagnostic codes TW5001 and TW5002 for dry-run

### DIFF
--- a/src/Typewriter.Application/Diagnostics/DiagnosticCode.cs
+++ b/src/Typewriter.Application/Diagnostics/DiagnosticCode.cs
@@ -53,6 +53,12 @@ public static class DiagnosticCode
     /// <summary>Output write error.</summary>
     public const string TW4001 = "TW4001";
 
+    /// <summary>Dry-run: would write file.</summary>
+    public const string TW5001 = "TW5001";
+
+    /// <summary>Dry-run complete summary.</summary>
+    public const string TW5002 = "TW5002";
+
     /// <summary>Internal violation.</summary>
     public const string TW9001 = "TW9001";
 }


### PR DESCRIPTION
## Summary
- Adds `TW5001` (Info): "Dry-run: would write file" — emitted per file that would be written
- Adds `TW5002` (Info): "Dry-run complete summary" — emitted as a summary after the template loop
- Both codes follow existing `TWxxxx` format in the TW5xxx range

Closes #257

## Test plan
- [x] `dotnet build -c Release` passes (0 errors)
- [x] `dotnet test -c Release` passes (185/185 tests)
- [x] Codes follow existing naming conventions and format
- [x] Codes are CI-parseable per AGENTS.md §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)