### PR TITLE
feat: add DryRun property to TypewriterConfig

### DIFF
--- a/src/Typewriter.Application/Configuration/TypewriterConfig.cs
+++ b/src/Typewriter.Application/Configuration/TypewriterConfig.cs
@@ -12,4 +12,7 @@ public class TypewriterConfig
     public string? Output { get; set; }
     public string? Verbosity { get; set; }
     public bool? FailOnWarnings { get; set; }
+
+    /// <summary>When <c>true</c>, enables dry-run mode so no files are written to disk.</summary>
+    public bool? DryRun { get; set; }
 }

--- a/tests/Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs
+++ b/tests/Typewriter.UnitTests/Configuration/ConfigurationPrecedenceTests.cs
@@ -271,6 +271,48 @@ public class ConfigurationPrecedenceTests
     }
 
     [Fact]
+    public void Loader_ParsesDryRunFromJson()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Directory.CreateDirectory(Path.Combine(tempDir, ".git"));
+
+        var json = """{"dryRun": true}""";
+        File.WriteAllText(Path.Combine(tempDir, "typewriter.json"), json);
+        try
+        {
+            var result = TypewriterConfigLoader.Load(tempDir);
+            Assert.NotNull(result);
+            Assert.True(result.DryRun);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Loader_DryRunIsNullWhenNotSpecified()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Directory.CreateDirectory(Path.Combine(tempDir, ".git"));
+
+        var json = """{"framework": "net10.0"}""";
+        File.WriteAllText(Path.Combine(tempDir, "typewriter.json"), json);
+        try
+        {
+            var result = TypewriterConfigLoader.Load(tempDir);
+            Assert.NotNull(result);
+            Assert.Null(result.DryRun);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Loader_ThrowsOrReturnsNull_OnMalformedJson()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());


### PR DESCRIPTION
## Summary
- Adds `public bool? DryRun { get; set; }` to `TypewriterConfig` so dry-run mode can be configured via `typewriter.json`
- Property is nullable to distinguish "not set" from "explicitly false"
- Adds two unit tests verifying JSON deserialization (true value and null-when-absent)

Closes #259

## Test plan
- [x] New `Loader_ParsesDryRunFromJson` test passes
- [x] New `Loader_DryRunIsNullWhenNotSpecified` test passes
- [x] All 185 existing tests continue to pass
- [x] `dotnet build -c Release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)