### PR TITLE
feat: wire dry-run mode in ApplicationRunner.RunAsync

### DIFF
--- a/src/Typewriter.Application/ApplicationRunner.cs
+++ b/src/Typewriter.Application/ApplicationRunner.cs
@@ -163,6 +163,22 @@ public sealed class ApplicationRunner
         timer.StartStage("write");
 
         // 8. Execute templates against loaded metadata.
+        // When dry-run mode is active, wrap the real writer so that file I/O is suppressed
+        // while the rest of the pipeline (load → metadata → render) executes normally.
+        DryRunOutputWriter? dryRunWriter = null;
+        IOutputWriter effectiveWriter = _outputWriter;
+        if (options.DryRun)
+        {
+            dryRunWriter = new DryRunOutputWriter(_outputWriter, filePath =>
+            {
+                reporter.Report(new DiagnosticMessage(
+                    DiagnosticSeverity.Info,
+                    DiagnosticCode.TW5001,
+                    $"Dry-run: would write '{filePath}'."));
+            });
+            effectiveWriter = dryRunWriter;
+        }
+
         var metadataProvider = new RoslynMetadataProvider(workspaceResult);
         var solutionFullName = resolvedInput.SolutionDirectory ?? resolvedInput.ProjectPath;
         var compiler = new Compiler(_cache);
@@ -185,7 +201,7 @@ public sealed class ApplicationRunner
                     templatePath,
                     solutionFullName,
                     _outputPathPolicy,
-                    _outputWriter,
+                    effectiveWriter,
                     compiler,
                     error =>
                     {
@@ -230,6 +246,15 @@ public sealed class ApplicationRunner
         }
 
         timer.StopStage();
+
+        // Emit dry-run summary when applicable.
+        if (dryRunWriter is not null)
+        {
+            reporter.Report(new DiagnosticMessage(
+                DiagnosticSeverity.Info,
+                DiagnosticCode.TW5002,
+                $"Dry-run complete: {dryRunWriter.FileCount} file(s) would have been written."));
+        }
 
         // Emit stage timings at detailed verbosity or above.
         if (string.Equals(options.Verbosity, "detailed", StringComparison.OrdinalIgnoreCase)

--- a/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
+++ b/tests/Typewriter.UnitTests/Cli/CliContractTests.cs
@@ -248,6 +248,69 @@ public class CliContractTests : IDisposable
         Assert.Contains(messages, m => m.Code == DiagnosticCode.TW3001);
     }
 
+    /// <summary>
+    /// Verifies that when <c>DryRun</c> is true, the runner emits a <c>TW5002</c> summary
+    /// diagnostic and still returns exit code 0.
+    /// </summary>
+    [Fact]
+    public async Task DryRun_EmptyWorkspace_EmitsTW5002AndReturns0()
+    {
+        var runner = CreateRunner();
+        var messages = new List<DiagnosticMessage>();
+        var reporter = new CapturingDiagnosticReporter(messages);
+        var templatePath = CreateTempTemplate();
+
+        var options = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     [templatePath],
+            solution:      "my.sln",
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false,
+            dryRun:        true);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(messages, m => m.Code == DiagnosticCode.TW5002);
+    }
+
+    /// <summary>
+    /// Verifies that when <c>DryRun</c> is false, no <c>TW5002</c> diagnostic is emitted.
+    /// </summary>
+    [Fact]
+    public async Task NoDryRun_EmptyWorkspace_DoesNotEmitTW5002()
+    {
+        var runner = CreateRunner();
+        var messages = new List<DiagnosticMessage>();
+        var reporter = new CapturingDiagnosticReporter(messages);
+        var templatePath = CreateTempTemplate();
+
+        var options = GenerateCommandOptions.Merge(
+            config:        null,
+            templates:     [templatePath],
+            solution:      "my.sln",
+            project:       null,
+            framework:     null,
+            configuration: null,
+            runtime:       null,
+            restore:       false,
+            output:        null,
+            verbosity:     null,
+            failOnWarnings: false,
+            dryRun:        false);
+
+        var exitCode = await runner.RunAsync(options, reporter);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain(messages, m => m.Code == DiagnosticCode.TW5002);
+    }
+
     /// <summary>Verifies that passing <c>--dry-run</c> sets <see cref="GenerateCommandOptions.DryRun"/> to <c>true</c>.</summary>
     [Fact]
     public void DryRun_WhenSpecified_SetsOptionToTrue()


### PR DESCRIPTION
## Summary

- Wraps the injected `IOutputWriter` with `DryRunOutputWriter` when `options.DryRun` is true, suppressing file I/O during the write stage
- Emits `TW5001` info diagnostic per file via the decorator callback
- Emits `TW5002` summary diagnostic after the template rendering loop with the count of files that would have been written
- Full pipeline (load → metadata → render) still executes normally — only write behavior changes
- Exit codes unchanged

## Test plan

- [x] New test `DryRun_EmptyWorkspace_EmitsTW5002AndReturns0` verifies TW5002 is emitted and exit code is 0 when dry-run is active
- [x] New test `NoDryRun_EmptyWorkspace_DoesNotEmitTW5002` verifies TW5002 is not emitted when dry-run is inactive
- [x] All existing tests pass (173 unit + 13 integration + 6 golden + 3 performance)

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)