### PR TITLE
fix: guard class-library projects from single-file publish

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,4 +17,9 @@
     <Copyright>Copyright © Typewriter Contributors. All rights reserved.</Copyright>
   </PropertyGroup>
 
+  <!-- Prevent NETSDK1099 when publishing at solution level with /p:PublishSingleFile=true -->
+  <PropertyGroup Condition="'$(OutputType)' != 'Exe'">
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- Add conditional `<IsPublishable>false</IsPublishable>` in `Directory.Build.props` for projects where `OutputType` is not `Exe`
- Prevents `NETSDK1099` errors when running `dotnet publish` at solution level with `/p:PublishSingleFile=true`
- Only the CLI executable project will be published as single-file; class libraries are skipped

## Verification
All commands pass:
- `dotnet restore` ✓
- `dotnet build -c Release` ✓ (0 errors)
- `dotnet test -c Release` ✓ (203 tests passed)
- `dotnet pack -c Release` ✓

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)