### PR TITLE
feat: add single-file-safe assembly location resolver in ShadowClass

### DIFF
--- a/src/Typewriter.Generation/ShadowClass.cs
+++ b/src/Typewriter.Generation/ShadowClass.cs
@@ -209,6 +209,48 @@ public class ShadowClass
         return compilation.Emit(fileStream);
     }
 
+    /// <summary>
+    /// Resolves the file path of an assembly safely in both normal and single-file deployment
+    /// modes, where <see cref="Assembly.Location"/> returns an empty string.
+    /// </summary>
+    /// <param name="assembly">The assembly to resolve.</param>
+    /// <returns>
+    /// The absolute file path of the assembly, or <c>null</c> if no path can be resolved.
+    /// </returns>
+    internal static string? ResolveAssemblyPath(Assembly assembly)
+    {
+#pragma warning disable IL3000 // Assembly.Location returns empty in single-file — handled by fallbacks below
+        var location = assembly.Location;
+#pragma warning restore IL3000
+
+        if (!string.IsNullOrEmpty(location))
+        {
+            return location;
+        }
+
+        // Fallback: AppContext.BaseDirectory + assembly simple name + ".dll"
+        var baseDirCandidate = Path.Combine(AppContext.BaseDirectory, assembly.GetName().Name + ".dll");
+        if (File.Exists(baseDirCandidate))
+        {
+            return baseDirCandidate;
+        }
+
+        // Fallback: TRUSTED_PLATFORM_ASSEMBLIES lookup by filename
+        var fileName = assembly.GetName().Name + ".dll";
+        var trustedAssemblies = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)?
+            .Split(Path.PathSeparator) ?? [];
+
+        var match = trustedAssemblies
+            .FirstOrDefault(a => string.Equals(Path.GetFileName(a), fileName, StringComparison.OrdinalIgnoreCase));
+
+        if (match != null)
+        {
+            return match;
+        }
+
+        return null;
+    }
+
     private static void AddTrustedPlatformAssembly(List<MetadataReference> references, string assemblyFileName)
     {
         var trustedAssemblies = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)?


### PR DESCRIPTION
## Summary
- Adds `internal static string? ResolveAssemblyPath(Assembly assembly)` to `ShadowClass` that safely resolves an assembly's file path in both normal and single-file deployment modes.
- Uses a three-step probe chain: `Assembly.Location`, `AppContext.BaseDirectory` + simple name + `.dll`, and `TRUSTED_PLATFORM_ASSEMBLIES` lookup by filename.
- Suppresses `IL3000` with a targeted pragma since the fallback probes handle the empty-location case.

Closes #275

## Test plan
- [x] Build succeeds with `dotnet build -c Release` (0 errors, no IL3000 warnings)
- [x] All 203 tests pass with `dotnet test -c Release`
- [ ] Unit tests for fallback paths to be added in a follow-up task

🤖 Generated with [Claude Code](https://claude.com/claude-code)