### PR TITLE
fix: use ResolveAssemblyPath in ShadowClass.Compile to avoid IL3000

### DIFF
--- a/src/Typewriter.Generation/ShadowClass.cs
+++ b/src/Typewriter.Generation/ShadowClass.cs
@@ -181,8 +181,9 @@ public class ShadowClass
         syntaxTree = root.SyntaxTree;
 
         var metadataReferences = _referencedAssemblies
-            .Where(a => !string.IsNullOrEmpty(a.Location))
-            .Select(a => MetadataReference.CreateFromFile(a.Location))
+            .Select(ResolveAssemblyPath)
+            .Where(path => path != null)
+            .Select(path => MetadataReference.CreateFromFile(path!))
             .Cast<MetadataReference>()
             .ToList();
 


### PR DESCRIPTION
## Summary

- Replace direct `Assembly.Location` usage in `ShadowClass.Compile` (lines 183-185) with the single-file-safe `ResolveAssemblyPath` helper, eliminating `IL3000` warnings in single-file publish mode.
- Assemblies where the resolver returns `null` are excluded, preserving the same filtering behavior as the previous empty-location check.

Closes #276

## Test plan

- [x] `dotnet build -c Release` succeeds with no IL3000 warnings on affected lines
- [x] All 203 existing tests pass (`dotnet test -c Release`)
- [x] No behavior change in non-single-file mode (same deterministic ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)