### PR TITLE
fix: use ResolveAssemblyPath in AddCoreReferenceIfMissing for single-file safety

### DIFF
--- a/src/Typewriter.Generation/ShadowClass.cs
+++ b/src/Typewriter.Generation/ShadowClass.cs
@@ -267,9 +267,11 @@ public class ShadowClass
 
     private static void AddCoreReferenceIfMissing(List<MetadataReference> references, System.Type type)
     {
-        var location = type.Assembly.Location;
-        if (string.IsNullOrEmpty(location))
+        var location = ResolveAssemblyPath(type.Assembly);
+        if (location == null)
         {
+            // Resolver exhausted all fallbacks; try TPA lookup by filename as last resort.
+            AddTrustedPlatformAssembly(references, type.Assembly.GetName().Name + ".dll");
             return;
         }
 


### PR DESCRIPTION
## Summary

- Replaced direct `type.Assembly.Location` access in `AddCoreReferenceIfMissing` with the `ResolveAssemblyPath` helper, eliminating the IL3000 warning and enabling correct resolution in single-file publish mode.
- When the resolver returns `null`, falls back to TPA lookup by filename via the existing `AddTrustedPlatformAssembly` helper.
- Maintains the existing deduplication check against the `references` list.

Closes #277

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test -c Release` — all 203 tests pass (180 unit + 14 integration + 6 golden + 3 performance)
- [x] No direct `Assembly.Location` usage in `AddCoreReferenceIfMissing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)