### PR TITLE
fix: use ResolveAssemblyPath in Compiler to eliminate IL3000

### DIFF
--- a/src/Typewriter.Generation/Compiler.cs
+++ b/src/Typewriter.Generation/Compiler.cs
@@ -59,7 +59,7 @@ public sealed class Compiler
             // can resolve them at runtime.
             foreach (var refAsm in shadowClass.ReferencedAssemblies)
             {
-                var asmSourcePath = refAsm.Location;
+                var asmSourcePath = ShadowClass.ResolveAssemblyPath(refAsm);
                 if (string.IsNullOrEmpty(asmSourcePath))
                 {
                     continue;


### PR DESCRIPTION
## Summary

- Replace direct `refAsm.Location` with `ShadowClass.ResolveAssemblyPath(refAsm)` in `Compiler.Compile` to eliminate IL3000 warnings and support single-file publish mode.
- The existing null/empty guard continues to skip assemblies with no resolvable path.

Closes #278

## Test plan

- [x] `dotnet build -c Release` succeeds with no IL3000 warning for `Compiler.cs`
- [x] All 203 tests pass (`dotnet test -c Release`)
- [x] No direct `Assembly.Location` usage remains in `Compiler.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)