### PR TITLE
chore: verify single-file publish support

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -1,6 +1,6 @@
 # Progress Tracker
 
-> Last touched: 2026-03-05 by Claude (Executor, #265)
+> Last touched: 2026-03-05 by Claude (Executor, #280)
 
 ## Current State
 
@@ -123,6 +123,7 @@
 | #182 Document performance budgets in README.md | M9 | Executor | Done | `tests/Typewriter.PerformanceTests/README.md` — wall-time (60 s), memory (2 GB), run command, update process, fixture description |
 | #183 Run M9 acceptance criteria verification | M9 | Executor | Done | All M9 gates verified: restore/build/test pass (185/185); functional suite clean (182 non-perf); LargeSolution perf test passes (15s < 60s budget); stage timings in ApplicationRunner at --verbosity detailed; ci.yml updated with performance filter + dedicated job; budgets documented in README.md; M9→Done, active→Complete |
 | #265 Run verification for dry-run feature | Post | Executor | Done | Dry-run feature verification (§8): restore/build/test all pass; 203/203 tests (180 unit + 14 integration + 6 golden + 3 performance); 0 errors, 0 failures |
+| #280 Run verification for single-file publish | Post | Executor | Done | Single-file publish verification (§8): restore/build/test/pack all pass; 210/210 tests (187 unit + 14 integration + 6 golden + 3 performance); 0 errors, 0 IL3000 warnings, 0 failures |
 
 ## Decisions
 


### PR DESCRIPTION
## Summary

- Ran the full mandatory verification suite (AGENTS.md §8) confirming all single-file publish changes are correct with no regressions
- `dotnet restore` — success
- `dotnet build -c Release` — 0 errors, 0 IL3000 warnings (only unrelated MinVer deprecation notice)
- `dotnet test -c Release` — 210/210 tests pass (187 unit + 14 integration + 6 golden + 3 performance)
- `dotnet pack -c Release` — success, all 7 .nupkg files produced

## Test plan

- [x] `dotnet restore` succeeds
- [x] `dotnet build -c Release` succeeds with zero errors and no IL3000 warnings
- [x] `dotnet test -c Release` succeeds with all 210 tests passing
- [x] `dotnet pack -c Release` succeeds

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)