### PR TITLE
chore: verify no-args help feature (#284)

### DIFF
--- a/.ai/progress.md
+++ b/.ai/progress.md
@@ -126,6 +126,7 @@
 | #280 Run verification for single-file publish | Post | Executor | Done | Single-file publish verification (§8): restore/build/test/pack all pass; 210/210 tests (187 unit + 14 integration + 6 golden + 3 performance); 0 errors, 0 IL3000 warnings, 0 failures |
 | #282 Add early-exit help invocation for no-args case in Program.cs | Post | Executor | Done | Added no-args early exit in `Program.cs` to invoke help and return 0; verified `dotnet restore`, `dotnet build -c Release`, `dotnet test -c Release` all pass (210/210), plus no-args CLI smoke check (`stdout` help, `generate` present, `exit 0`) |
 | #283 Add CLI contract test for no-args help behavior | Post | Executor | Done | Added `NoArgs_PrintsHelpAndReturns0` in `CliContractTests`; asserts empty args exit code 0 and help content contains `typewriter-cli` and `generate`; verification passed (`dotnet restore`, `dotnet build -c Release`, `dotnet test -c Release`: 211/211 tests) |
+| #284 Run verification for no-args help feature | Post | Executor | Done | No-args help verification (§8): restore/build/test all pass; 211/211 tests (188 unit + 14 integration + 6 golden + 3 performance); 0 errors, 0 failures |
 
 ## Decisions
 

--- a/.ai/tasks/T284-verify-no-args-help.md
+++ b/.ai/tasks/T284-verify-no-args-help.md
@@ -1,0 +1,34 @@
+# T284: Verify no-args help feature
+
+- Milestone: Post
+- Status: Done
+- Agent: Executor (#284)
+- Started: 2026-03-05
+- Completed: 2026-03-05
+
+## Objective
+
+Run mandatory pre-completion verification commands (AGENTS.md §8) to confirm the no-args help feature works correctly.
+
+## Verification Results
+
+All three commands passed:
+
+### dotnet restore
+- 12 projects restored successfully
+- No errors
+
+### dotnet build -c Release
+- Build succeeded
+- 0 errors, 1 warning (pre-existing MinVer MINVER1008 deprecation)
+
+### dotnet test -c Release
+- 211 total tests passed, 0 failures
+  - 188 unit tests (Typewriter.UnitTests)
+  - 14 integration tests (Typewriter.IntegrationTests)
+  - 6 golden tests (Typewriter.GoldenTests)
+  - 3 performance tests (Typewriter.PerformanceTests)
+
+## Outcome
+
+All acceptance criteria met. The no-args help feature (from #282 and #283) is verified working correctly.


### PR DESCRIPTION
## Summary

- Ran mandatory pre-completion verification commands (AGENTS.md §8) to confirm the no-args help feature from #282 and #283 works correctly
- All three verification commands pass: `dotnet restore`, `dotnet build -c Release`, `dotnet test -c Release`
- 211/211 tests pass (188 unit + 14 integration + 6 golden + 3 performance), 0 failures

Closes #284

## Test plan

- [x] `dotnet restore` succeeds
- [x] `dotnet build -c Release` succeeds with no errors
- [x] `dotnet test -c Release` succeeds with all 211 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)