### PR TITLE
feat: add best-effort stale directory cleanup in Compiler

### DIFF
--- a/src/Typewriter.Generation/Compiler.cs
+++ b/src/Typewriter.Generation/Compiler.cs
@@ -22,6 +22,11 @@ public sealed class Compiler
 {
     private static readonly string TempDirectory = Path.Combine(Path.GetTempPath(), "Typewriter");
 
+    /// <summary>
+    /// Subdirectories older than this threshold are considered stale and eligible for cleanup.
+    /// </summary>
+    internal static readonly TimeSpan StaleThreshold = TimeSpan.FromHours(24);
+
     private readonly InvocationCache _cache;
     private readonly string _subDirectory;
 
@@ -36,6 +41,55 @@ public sealed class Compiler
     {
         _cache = cache;
         _subDirectory = Path.Combine(TempDirectory, Guid.NewGuid().ToString("N"));
+        CleanupStaleDirectories(TempDirectory, StaleThreshold);
+    }
+
+    /// <summary>
+    /// Scans <paramref name="parentDirectory"/> for subdirectories whose last write time is
+    /// older than <paramref name="threshold"/> and deletes them on a best-effort basis.
+    /// All IO-related exceptions are swallowed so cleanup never disrupts the current invocation.
+    /// </summary>
+    /// <param name="parentDirectory">The parent temp directory to scan.</param>
+    /// <param name="threshold">Age threshold beyond which a subdirectory is considered stale.</param>
+    internal static void CleanupStaleDirectories(string parentDirectory, TimeSpan threshold)
+    {
+        try
+        {
+            if (!Directory.Exists(parentDirectory))
+            {
+                return;
+            }
+
+            var cutoff = DateTime.UtcNow - threshold;
+
+            foreach (var subDir in Directory.EnumerateDirectories(parentDirectory))
+            {
+                try
+                {
+                    var lastWrite = Directory.GetLastWriteTimeUtc(subDir);
+                    if (lastWrite < cutoff)
+                    {
+                        Directory.Delete(subDir, recursive: true);
+                    }
+                }
+                catch (IOException)
+                {
+                    // Locked files or in-use directory; skip silently.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Permission denied; skip silently.
+                }
+            }
+        }
+        catch (IOException)
+        {
+            // Parent directory became inaccessible; nothing to do.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // No permission to enumerate parent; nothing to do.
+        }
     }
 
     /// <summary>

--- a/src/Typewriter.Generation/Typewriter.Generation.csproj
+++ b/src/Typewriter.Generation/Typewriter.Generation.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Typewriter.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Typewriter.CodeModel\Typewriter.CodeModel.csproj" />
     <ProjectReference Include="..\Typewriter.Metadata\Typewriter.Metadata.csproj" />
     <ProjectReference Include="..\Typewriter.Metadata.Roslyn\Typewriter.Metadata.Roslyn.csproj" />

--- a/tests/Typewriter.UnitTests/Generation/CompilerStaleCleanupTests.cs
+++ b/tests/Typewriter.UnitTests/Generation/CompilerStaleCleanupTests.cs
@@ -1,0 +1,101 @@
+using Typewriter.Generation;
+using Xunit;
+
+namespace Typewriter.UnitTests.Generation;
+
+/// <summary>
+/// Tests for <see cref="Compiler.CleanupStaleDirectories"/> which removes stale
+/// temp subdirectories left behind by crashed or interrupted invocations.
+/// </summary>
+public class CompilerStaleCleanupTests : IDisposable
+{
+    private readonly string _testRoot;
+
+    public CompilerStaleCleanupTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), $"TypewriterTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that subdirectories older than the threshold are deleted.
+    /// </summary>
+    [Fact]
+    public void CleanupStaleDirectories_DeletesOldSubdirectories()
+    {
+        var staleDir = Path.Combine(_testRoot, "stale");
+        Directory.CreateDirectory(staleDir);
+        Directory.SetLastWriteTimeUtc(staleDir, DateTime.UtcNow.AddHours(-48));
+
+        Compiler.CleanupStaleDirectories(_testRoot, TimeSpan.FromHours(24));
+
+        Assert.False(Directory.Exists(staleDir));
+    }
+
+    /// <summary>
+    /// Verifies that subdirectories within the threshold are not deleted.
+    /// </summary>
+    [Fact]
+    public void CleanupStaleDirectories_PreservesRecentSubdirectories()
+    {
+        var recentDir = Path.Combine(_testRoot, "recent");
+        Directory.CreateDirectory(recentDir);
+        // Last write time defaults to now, well within 24-hour threshold.
+
+        Compiler.CleanupStaleDirectories(_testRoot, TimeSpan.FromHours(24));
+
+        Assert.True(Directory.Exists(recentDir));
+    }
+
+    /// <summary>
+    /// Verifies that a mix of stale and recent directories results in only stale ones being removed.
+    /// </summary>
+    [Fact]
+    public void CleanupStaleDirectories_DeletesOnlyStaleDirectories()
+    {
+        var staleDir = Path.Combine(_testRoot, "old");
+        var recentDir = Path.Combine(_testRoot, "new");
+        Directory.CreateDirectory(staleDir);
+        Directory.CreateDirectory(recentDir);
+        Directory.SetLastWriteTimeUtc(staleDir, DateTime.UtcNow.AddHours(-48));
+
+        Compiler.CleanupStaleDirectories(_testRoot, TimeSpan.FromHours(24));
+
+        Assert.False(Directory.Exists(staleDir));
+        Assert.True(Directory.Exists(recentDir));
+    }
+
+    /// <summary>
+    /// Verifies that cleanup does not throw when the parent directory does not exist.
+    /// </summary>
+    [Fact]
+    public void CleanupStaleDirectories_NoExceptionWhenParentMissing()
+    {
+        var nonExistent = Path.Combine(_testRoot, "does_not_exist");
+
+        var exception = Record.Exception(() =>
+            Compiler.CleanupStaleDirectories(nonExistent, TimeSpan.FromHours(24)));
+
+        Assert.Null(exception);
+    }
+
+    /// <summary>
+    /// Verifies that cleanup does not throw when the parent directory is empty.
+    /// </summary>
+    [Fact]
+    public void CleanupStaleDirectories_NoExceptionWhenEmpty()
+    {
+        var exception = Record.Exception(() =>
+            Compiler.CleanupStaleDirectories(_testRoot, TimeSpan.FromHours(24)));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `CleanupStaleDirectories` static helper to `Compiler` that scans the `Typewriter` temp directory for subdirectories older than 24 hours and deletes them on a best-effort basis
- Called automatically in the `Compiler` constructor on each invocation
- All IO exceptions (locked files, permission issues) are swallowed to avoid disrupting the current compilation
- Add `InternalsVisibleTo` for test project access to internal members
- Add 5 unit tests covering stale/recent/mixed directories, missing parent, and empty parent scenarios

Closes #305

## Test plan

- [x] New unit tests pass (`CompilerStaleCleanupTests` — 5 tests)
- [x] Full test suite passes (216 tests across unit, integration, golden, and performance)
- [x] Build succeeds in Release configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)